### PR TITLE
バックグラウンド通信の実装

### DIFF
--- a/NearU/Info.plist
+++ b/NearU/Info.plist
@@ -13,7 +13,5 @@
     </array>
     <key>NSBluetoothAlwaysUsageDescription</key>
     <string>このアプリはBLE通信を使用します。</string>
-    <key>NSBluetoothPeripheralUsageDescription</key>
-    <string>このアプリはBLEペリフェラルとして動作するためにBluetoothを使用します。</string>
 </dict>
 </plist>

--- a/NearU/Model/User.swift
+++ b/NearU/Model/User.swift
@@ -7,9 +7,11 @@
 
 import SwiftUI
 import Firebase
+import FirebaseFirestoreSwift
 
 struct User: Identifiable, Hashable, Codable {
-    let id: String
+    var id: String
+    let uid: String
     var username: String
     var profileImageUrl: String?
     var backgroundImageUrl: String?
@@ -22,15 +24,15 @@ struct User: Identifiable, Hashable, Codable {
 
     var isCurrentUser: Bool {
         guard let currentUid = Auth.auth().currentUser?.uid else { return false } //現在のユーザ情報があればそれをcurrentUidに格納
-        return currentUid == id
+        return currentUid == uid
     }
 }
 
 extension User {
     static var MOCK_USERS: [User] = [
-        .init(id: NSUUID().uuidString, username: "ironman", profileImageUrl: "ironman1", fullname: "Tony Stark", bio: "I am ironman", email: "ironman@gmail.com", isPrivate: false, connectList: [], snsLinks: [:]),
+        .init(id: "FEstc1eg",uid: NSUUID().uuidString, username: "ironman", profileImageUrl: "ironman1", fullname: "Tony Stark", bio: "I am ironman", email: "ironman@gmail.com", isPrivate: false, connectList: [], snsLinks: [:]),
 
-        .init(id: NSUUID().uuidString, username: "spiderman", profileImageUrl: "spiderman1", fullname: "peter parker",
+            .init(id: "FEstc1eg", uid: NSUUID().uuidString, username: "spiderman", profileImageUrl: "spiderman1", fullname: "peter parker",
               bio: "With great power comes great responsibility", email: "spiderman@gmail.com", isPrivate: true, connectList: [], snsLinks: [:])
     ]
 }

--- a/NearU/Service/AuthService.swift
+++ b/NearU/Service/AuthService.swift
@@ -34,27 +34,61 @@ class AuthService {
     }
 
     @MainActor
-    //新規ユーザを作成する関数
+    // 新規ユーザを作成する関数
     func createUser(email: String, password: String, username: String) async throws {
         do {
-            let result = try await Auth.auth().createUser(withEmail: email, password: password) //FirebaseAuthenticationに新規ユーザを登録
-            self.userSession = result.user //新規登録されたユーザーの情報をuserSessionに格納する．userはAuthDataResultのプロパティ．ユーザの情報を含む．
-            await uploadUserData(uid: result.user.uid, username: username, email: email, isPrivate: false) //関数を非同期に実行
+            // Firebase Authenticationに新規ユーザを登録
+            let result = try await Auth.auth().createUser(withEmail: email, password: password)
+            self.userSession = result.user // 新規登録されたユーザーの情報をuserSessionに格納
+
+            // ユニークなuserIdが生成されるまで繰り返す
+            var documentId = ""
+            var isUnique = false
+
+            repeat {
+                documentId = generateRandomDocumentId() // ランダムなuserIdを生成
+                isUnique = try await isDocumentIdUnique(documentId) // 一意性を確認
+            } while !isUnique // 一意になるまで繰り返す
+
+            // 一意なuserIdが確定したら、Firestoreにユーザーデータを保存
+            await uploadUserData(id: documentId, uid: result.user.uid, username: username, email: email, isPrivate: false)
 
         } catch {
             print("DEBUG: Failed to register user with error \(error.localizedDescription)")
+            throw error // エラーをスロー
         }
     }
 
-    @MainActor
-    //ユーザデータを読み込む関数
-    func loadUserData() async throws {
-        self.userSession = Auth.auth().currentUser //FirebaseAuthenticationから現在のユーザデータ情報を取得しuserSessionに格納
-        guard let currentUid = userSession?.uid else { return } //currentUserのユーザidを取得し，currentUidに格納
-        self.currentUser = try await UserService.fetchUser(withUid: currentUid)
-        let snapshot = try await Firestore.firestore().collection("users").document(currentUid).getDocument()
-        self.currentUser = try? snapshot.data(as: User?.self)
+    // 8文字のランダムなdocumentIdを生成する関数
+    private func generateRandomDocumentId(length: Int = 8) -> String {
+        let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        return String((0..<length).compactMap { _ in characters.randomElement() })
     }
+
+    func isDocumentIdUnique(_ userId: String) async throws -> Bool {
+        let query = Firestore.firestore().collection("users").whereField("userId", isEqualTo: userId).limit(to: 1)
+        let snapshot = try await query.getDocuments()
+        return snapshot.isEmpty
+    }
+
+    @MainActor
+    func loadUserData() async throws {
+        self.userSession = Auth.auth().currentUser // Firebase Authenticationから現在のユーザデータ情報を取得
+        guard let currentUid = userSession?.uid else { return } // currentUserのuidを取得
+        // uidフィールドがcurrentUidと一致するユーザードキュメントをクエリ
+        let querySnapshot = try await Firestore.firestore().collection("users").whereField("uid", isEqualTo: currentUid).getDocuments()
+
+        if let document = querySnapshot.documents.first {
+            // Firestoreから取得したデータをデコード
+            var user = try document.data(as: User.self)
+            // ドキュメントIDを手動でセット
+            user.id = document.documentID
+            self.currentUser = user
+        } else {
+            print("DEBUG: ユーザーデータが見つかりませんでした。")
+        }
+    }
+
 
     func signout() {
         try? Auth.auth().signOut() //try?はエラーを無視
@@ -67,21 +101,22 @@ class AuthService {
     }
 
     //Firestore Databaseにユーザ情報を追加する関数
-    private func uploadUserData(uid: String, username: String, email: String, isPrivate: Bool) async {
-        let user = User(id: uid, username: username, email: email, isPrivate: isPrivate, connectList: [], snsLinks: [:]) //インスタンス化
-        self.currentUser = user //curenntUserに現在のユーザ情報を格納
-        guard let encodedUser = try? Firestore.Encoder().encode(user) else { return } //ユーザ情報をJSONデータにエンコードしてencodedUserに格納
-        try? await Firestore.firestore().collection("users").document(user.id).setData(encodedUser) //encodedUser(JSONデータ？)をドキュメントに書き込む
-    }
+    private func uploadUserData(id: String, uid: String, username: String, email: String, isPrivate: Bool) async {
+        let user = User(id: id, uid: uid, username: username, email: email, isPrivate: isPrivate, connectList: [], snsLinks: [:]) // インスタンス化
+        self.currentUser = user
+        guard let encodedUser = try? Firestore.Encoder().encode(user) else { return }
 
+        // ドキュメントIDとしてuserIdを使用して保存
+        try? await Firestore.firestore().collection("users").document(user.id).setData(encodedUser)
+    }
     //受信したユーザーIDをFirebase Firestoreデータベースに保存する
     func addUserIdToFirestore(_ receivedUserId: String) async throws {
         //Firestoreのドキュメントに追加
         if let userId = self.currentUser?.id {
-            
+
             // TODO: ここのタイムスタンプはすれ違ったときの時間を引数で受け取って格納する
             let timestamp = Timestamp(date: Date())
-            
+
             try await Firestore.firestore().collection("users")
                 .document(userId)
                 .collection("connectList")

--- a/NearU/Service/BLECentralManager.swift
+++ b/NearU/Service/BLECentralManager.swift
@@ -6,31 +6,20 @@
 
 import CoreBluetooth
 import Foundation
+import Combine
 
-//BLEデバイスをスキャンして管理するクラス
-class BLECentralManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeripheralDelegate {
-    static let shared = BLECentralManager() //シングルトンインスタンス
-    //BLEデバイスのスキャンや接続管理をするためのインスタンス変数
+// BLEデバイスをスキャンして管理するクラス
+class BLECentralManager: NSObject, ObservableObject, CBCentralManagerDelegate {
+    static let shared = BLECentralManager() // シングルトンインスタンス
     var centralManager: CBCentralManager!
-    var discoveredPeripherals: [CBPeripheral] = [] //BLEデバイスのリストを保持
-    var userId: String?
-    var scanningTimer: Timer? // 定期的な出力用のタイマーを追加
-
+    var scanningTimer: Timer?
     let serviceUUID = CBUUID(string: "12345678-1234-1234-1234-1234567890ab")
-    let characteristicUUID = CBUUID(string: "87654321-4321-4321-4321-9876543210ba")
 
     private override init() {
-        //self.userId = user.id
         super.init()
-        //インスタンスを作成し，デリゲードをselfに設定
         centralManager = CBCentralManager(delegate: self, queue: nil)
     }
 
-    func configure(with user: User) {
-        self.userId = user.id
-    }
-
-    //Bluetoothの状態が変更されたときに呼び出される関数
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         if central.state == .poweredOn {
             let isOnBluetooth = UserDefaults.standard.bool(forKey: "isOnBluetooth")
@@ -42,55 +31,10 @@ class BLECentralManager: NSObject, ObservableObject, CBCentralManagerDelegate, C
         }
     }
 
-    //Bluetoothデバイスが発見されたときに呼び出される関数
-    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
-        //発見されたデバイスをリストに追加
-        discoveredPeripherals.append(peripheral)
-        //peripheralデバイスに接続を試みる
-        centralManager.connect(peripheral, options: nil)
-        //peripheral.discoverServices([serviceUUID])
-    }
-
-    //接続が成功した後に呼び出される関数
-    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        //peripheralのデリゲードを自信に設定
-        peripheral.delegate = self
-        //サービスを発見する
-        peripheral.discoverServices([serviceUUID])
-    }
-
-    //BLE周辺機器（ペリフェラル）のサービスが発見されたときに呼び出される関数
-    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        //発見されたサービスが存在するか確認
-        guard let services = peripheral.services else { return }
-        for service in services {
-            //サービスの特性を発見
-            peripheral.discoverCharacteristics([characteristicUUID], for: service)
-        }
-    }
-
-    //BLE周辺機器の特性が発見されたときに呼び出される関数
-    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
-        //特性の発見に成功しているか確認
-        guard let characteristics = service.characteristics else { return }
-        for characteristic in characteristics {
-            //特性のプロパティをチェックし、その特性が書き込み可能であるかを確認
-            if characteristic.properties.contains(.write) {
-                //ユーザーIDをUTF-8エンコードのデータ形式に変換
-                if let userId = userId {
-                    let userIdData = userId.data(using: .utf8)!
-                    //変換したユーザーIDデータを特性に書き込む
-                    peripheral.writeValue(userIdData, for: characteristic, type: .withResponse)
-                }
-            }
-        }
-    }
-    //バックグラウンド時に呼び出される関数
     func startScanning() {
         let isOnBluetooth = UserDefaults.standard.bool(forKey: "isOnBluetooth")
         if isOnBluetooth {
-            centralManager.scanForPeripherals(withServices: [serviceUUID],
-                                              options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+            centralManager.scanForPeripherals(withServices: [serviceUUID], options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
             print("start Scanning")
 
             scanningTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true, block: { _ in
@@ -99,8 +43,22 @@ class BLECentralManager: NSObject, ObservableObject, CBCentralManagerDelegate, C
         }
     }
 
+    // スキャン時に周囲のペリフェラルを発見したときに呼ばれる
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
+        // CBAdvertisementDataLocalNameKeyKeyを確認
+        if let receivedDocumentId = advertisementData[CBAdvertisementDataLocalNameKey] as? String {
+            print("Received userId (LocalName): \(receivedDocumentId), RSSI: \(RSSI)")
+            DispatchQueue.main.async {
+                // 受信したuserIdをRealmに保存
+                RealmManager.shared.storeData(receivedDocumentId)
+            }
+        }
+    }
+
     func stopScan() {
         centralManager.stopScan()
+        scanningTimer?.invalidate()
+        scanningTimer = nil
         print("stop Scan")
     }
 
@@ -108,5 +66,8 @@ class BLECentralManager: NSObject, ObservableObject, CBCentralManagerDelegate, C
         self.stopScan()
         self.centralManager.delegate = nil
     }
-
 }
+
+
+
+

--- a/NearU/Service/BLEPeripheralManager.swift
+++ b/NearU/Service/BLEPeripheralManager.swift
@@ -9,26 +9,22 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestoreSwift
 import Firebase
+import Combine
 
 // デバイスがペリフェラルとしてデータを提供するためのクラス
 class BLEPeripheralManager: NSObject, ObservableObject, CBPeripheralManagerDelegate {
     static let shared = BLEPeripheralManager() // シングルトンインスタンス
-    // サービスやキャラクタリスティックの作成を管理するインスタンス変数
     var peripheralManager: CBPeripheralManager!
-    var userId: String?
-    var advertisingTimer: Timer? // 定期的な出力用のタイマーを追加
+    var documentId: String?
+    var advertisingTimer: Timer?
 
-    let serviceUUID = CBUUID(string: "12345678-1234-1234-1234-1234567890ab")
-    let characteristicUUID = CBUUID(string: "87654321-4321-4321-4321-9876543210ba")
-
-    private override init() { // 外部プログラムからインスタンス生成ができないようにprivate
+    private override init() {
         super.init()
-        // インスタンスを作成し，デリゲードを自身に設定
         peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
     }
 
     func configure(with user: User) {
-        self.userId = user.id
+        self.documentId = user.id
     }
 
     func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
@@ -42,53 +38,20 @@ class BLEPeripheralManager: NSObject, ObservableObject, CBPeripheralManagerDeleg
         }
     }
 
-    // BLEペリフェラルが書き込みリクエストを受け取ったときに呼び出される関数
-    // userIdを受け取りRealmに保存
-    func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite requests: [CBATTRequest]) {
-        // 受け取ったリクエストを処理
-        for request in requests {
-            // リクエストからデータを取り出し，それをString型に変換
-            if let userIdData = request.value, let receivedUserId = String(data: userIdData, encoding: .utf8) {
-                // RealmManager.shared.storeData(receivedUserId) をバックグラウンドスレッドで呼び出す
-                DispatchQueue.main.async {
-                    RealmManager.shared.storeData(receivedUserId)
-                }
-                print("Received userId: \(receivedUserId)")
-            }
-            // centralmanagerに対して書き込みが成功したことを通知
-            peripheralManager.respond(to: request, withResult: .success)
-        }
-    }
-
     func startAdvertising() {
         let isOnBluetooth = UserDefaults.standard.bool(forKey: "isOnBluetooth")
         if isOnBluetooth {
-            // CBMutableCharacteristicを使って特性を作成
-            let characteristic = CBMutableCharacteristic(
-                type: characteristicUUID,
-                properties: [.write], // 書き込み可能
-                value: nil, // 初期値
-                permissions: [.writeable] // アクセス権，書き込み可能
-            )
-            // CBMutableServiceを使ってサービスを作成
-            let service = CBMutableService(type: serviceUUID, primary: true)
-            // サービスに作成した特性を追加
-            service.characteristics = [characteristic]
-            // ペリフェラルが提供するサービスとして登録
-            peripheralManager.add(service)
-            // startAdvertisingメソッドでBLEアドバタイズを開始
-            peripheralManager.startAdvertising([CBAdvertisementDataServiceUUIDsKey: [service.uuid],
-                                                   CBAdvertisementDataLocalNameKey: "Chonnect"])
+            guard let documentId = self.documentId else { return }
+
+            // アドバタイズデータに常にuserIdをLocalNameとして設定
+            let advertisementData: [String: Any] = [
+                CBAdvertisementDataServiceUUIDsKey: [CBUUID(string: "12345678-1234-1234-1234-1234567890ab")],
+                CBAdvertisementDataLocalNameKey: documentId
+            ]
+
+            peripheralManager.startAdvertising(advertisementData)
             print("start Advertising")
 
-            // アドバタイズが開始されたかを確認
-            if peripheralManager.isAdvertising {
-                print("アドバタイズが正常に開始されました")
-            } else {
-                print("アドバタイズが開始されていません")
-            }
-
-            // バックグラウンドでもアドバタイズが続いているかを確認するためのタイマー
             advertisingTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
                 if self.peripheralManager.isAdvertising {
                     print("アドバタイズが継続中")
@@ -111,4 +74,9 @@ class BLEPeripheralManager: NSObject, ObservableObject, CBPeripheralManagerDeleg
         self.peripheralManager.delegate = nil
     }
 }
+
+
+
+
+
 

--- a/NearU/Service/RealmManager.swift
+++ b/NearU/Service/RealmManager.swift
@@ -66,22 +66,33 @@ class RealmManager: ObservableObject {
     func removeData(_ userId: String) {
         do {
             let realm = try Realm()
+
+            // 該当するデータを検索
             if let existingEncountData = realm.objects(EncountData.self).filter("userId == %@", userId).first {
                 try realm.write {
+                    // Realmからデータを削除
                     realm.delete(existingEncountData)
                 }
                 print("User ID \(userId) has been removed from Realm.")
 
+                // `encountData`リストからも削除
                 if let index = self.encountData.firstIndex(where: { $0.userId == userId }) {
                     self.encountData.remove(at: index)
                     print("encountData removed for userId: \(userId)")
                 }
             }
+
+            // Realmに残っているデータの一覧を表示
+            let allEncountData = realm.objects(EncountData.self)
+            print("Current Realm data after deletion:")
+            for data in allEncountData {
+                print(data) // `EncountData`の各プロパティを表示する
+            }
+
         } catch {
             print("Error removing Realm data: \(error)")
         }
     }
-
 
     // RealmからEncountDataを取得する関数
     func getUserIDs() -> [EncountDataStruct] {

--- a/NearU/View/MainTabView.swift
+++ b/NearU/View/MainTabView.swift
@@ -41,7 +41,6 @@ struct MainTabView: View {
         } //tabview
         .accentColor(Color(.systemMint))
         .onAppear {
-            centralManager.configure(with: user)
             peripheralManager.configure(with: user)
 
             if centralManager.centralManager.state == .poweredOn {


### PR DESCRIPTION
## 概要
バックグラウンド状態，サスペンド状態でもアドバタイズパケットを受信してRealmに相手のIdを保存する機能を実装

## 追加・変更点
* BLEでのIdの通信方式をGATT通信（1対1）から単純なスキャンアドバタイズ（1対多）で行う仕様に変更(今後，近くのデバイスをリアルタイムで表示できるようにするため)
* User構造体にdocumentIdに対応した８文字のIdを格納するプロパティを追加(データに制限があったため，BLE通信ではこの8文字のIdをアドバタイズパケットに含んで送る)
* アカウント作成時にランダムな８文字のdocumentIdを生成する仕様に変更
* Realmに保存したデータが消せないバグを修正