### PR TITLE
connectListの参照先をサブコレクションにする

### DIFF
--- a/NearU.xcodeproj/project.pbxproj
+++ b/NearU.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		6387321E2BF4B7F80099F68A /* RegistrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6387321D2BF4B7F80099F68A /* RegistrationViewModel.swift */; };
 		638732232BF4BC770099F68A /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638732222BF4BC770099F68A /* ContentViewModel.swift */; };
 		63AEA5CB2CC4053C009A22A2 /* Tags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AEA5CA2CC4053C009A22A2 /* Tags.swift */; };
+		63AEA5CD2CC66B18009A22A2 /* UserDatePair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AEA5CC2CC66B18009A22A2 /* UserDatePair.swift */; };
 		63AEF0F92C0C4C2A00DE196E /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AEF0F82C0C4C2A00DE196E /* TopTabView.swift */; };
 		63AEF0FB2C0C4C6500DE196E /* ConnectedSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AEF0FA2C0C4C6500DE196E /* ConnectedSearchView.swift */; };
 		63AEF0FD2C0C507300DE196E /* WaitingSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AEF0FC2C0C507300DE196E /* WaitingSearchView.swift */; };
@@ -109,6 +110,7 @@
 		6387321D2BF4B7F80099F68A /* RegistrationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewModel.swift; sourceTree = "<group>"; };
 		638732222BF4BC770099F68A /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
 		63AEA5CA2CC4053C009A22A2 /* Tags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tags.swift; sourceTree = "<group>"; };
+		63AEA5CC2CC66B18009A22A2 /* UserDatePair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDatePair.swift; sourceTree = "<group>"; };
 		63AEF0F82C0C4C2A00DE196E /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		63AEF0FA2C0C4C6500DE196E /* ConnectedSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedSearchView.swift; sourceTree = "<group>"; };
 		63AEF0FC2C0C507300DE196E /* WaitingSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingSearchView.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				63135D9B2CB7A25A004137AF /* EncountData.swift */,
 				637B972B2CBA070D00EFB09F /* EncountDataStruct.swift */,
 				63AEA5CA2CC4053C009A22A2 /* Tags.swift */,
+				63AEA5CC2CC66B18009A22A2 /* UserDatePair.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -499,6 +502,7 @@
 				63DFF8802BF6F02A00A6DFB8 /* ProfileHeaderView.swift in Sources */,
 				638732232BF4BC770099F68A /* ContentViewModel.swift in Sources */,
 				63135DA32CB7ABCC004137AF /* RealmManager.swift in Sources */,
+				63AEA5CD2CC66B18009A22A2 /* UserDatePair.swift in Sources */,
 				6387321E2BF4B7F80099F68A /* RegistrationViewModel.swift in Sources */,
 				63B650052B8DDDF700289469 /* HomeView.swift in Sources */,
 				637BA0652C4970A800368566 /* MenuView.swift in Sources */,

--- a/NearU/Model/UserDatePair.swift
+++ b/NearU/Model/UserDatePair.swift
@@ -1,0 +1,13 @@
+//
+//  UserDatePair.swift
+//  NearU
+//
+//  Created by  髙橋和 on 2024/10/21.
+//
+
+import Foundation
+
+struct UserDatePair: Hashable, Codable {
+    let user: User
+    let date: Date
+}

--- a/NearU/Service/BLECentralManager.swift
+++ b/NearU/Service/BLECentralManager.swift
@@ -50,7 +50,7 @@ class BLECentralManager: NSObject, ObservableObject, CBCentralManagerDelegate {
             print("Received userId (LocalName): \(receivedDocumentId), RSSI: \(RSSI)")
             DispatchQueue.main.async {
                 // 受信したuserIdをRealmに保存
-                RealmManager.shared.storeData(receivedDocumentId)
+                RealmManager.shared.storeData(receivedDocumentId, date: Date())
             }
         }
     }

--- a/NearU/Service/RealmManager.swift
+++ b/NearU/Service/RealmManager.swift
@@ -32,28 +32,33 @@ class RealmManager: ObservableObject {
         }
     }
 
-    // すれ違ったユーザーIDを保存または更新
-    func storeData(_ receivedUserId: String) {
+    // すれ違ったユーザーIDと日付を保存または更新
+    func storeData(_ receivedUserId: String, date: Date) {
         do {
             let realm = try Realm()
+            // 既存のユーザーIDがRealmにあるか確認
             if let existingEncountData = realm.objects(EncountData.self).filter("userId == %@", receivedUserId).first {
+                // 既存データがあれば、日付を更新
                 try realm.write {
-                    existingEncountData.date = Date()
+                    existingEncountData.date = date
                 }
                 print("User ID \(receivedUserId) already exists, date updated in Realm.")
+                // メモリ上のencountData配列も更新
                 if let index = self.encountData.firstIndex(where: { $0.userId == receivedUserId }) {
                     self.encountData[index].date = existingEncountData.date
                 }
             } else {
+                // 新規データの作成
                 let newEncountData = EncountData()
                 newEncountData.userId = receivedUserId
-                newEncountData.date = Date()
+                newEncountData.date = date
 
+                // Realmに保存
                 try realm.write {
                     realm.add(newEncountData)
                 }
                 print("User ID \(receivedUserId) has been stored in Realm.")
-
+                // メモリ上の配列に追加
                 let newEncountDataStruct = EncountDataStruct(from: newEncountData)
                 self.encountData.append(newEncountDataStruct)
             }
@@ -61,7 +66,6 @@ class RealmManager: ObservableObject {
             print("Error storing Realm data: \(error)")
         }
     }
-
 
     func removeData(_ userId: String) {
         do {

--- a/NearU/Service/UserService.swift
+++ b/NearU/Service/UserService.swift
@@ -28,16 +28,16 @@ struct UserService {
         return users
     }
 
-    static func fetchConnectedUsers(withUid userId: String) async throws -> [User] {
-        // First, fetch the user to get their connectList
-        let user = try await fetchUser(withUid: userId)
-        let connectList = user.connectList
+    static func fetchConnectedUsers(documentId: String) async throws -> [UserDatePair] {
+        let snapshot = try await Firestore.firestore().collection("users").document(documentId).collection("connectList").getDocuments()
 
-        // Fetch the connected users
-        var connectedUsers: [User] = []
-        for connectedUserId in connectList {
-            let connectedUser = try await fetchUser(withUid: connectedUserId)
-            connectedUsers.append(connectedUser)
+        var connectedUsers: [UserDatePair] = []
+
+        for document in snapshot.documents {
+            let data = try document.data(as: EncountDataStruct.self)
+            let connectedUser = try await fetchUser(withUid: data.userId)
+            let userDatePair = UserDatePair(user: connectedUser, date: data.date)
+            connectedUsers.append(userDatePair)
         }
 
         return connectedUsers

--- a/NearU/View/Conpornents/ProfileHeaderView.swift
+++ b/NearU/View/Conpornents/ProfileHeaderView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ProfileHeaderView: View {
     @ObservedObject var viewModel: ProfileViewModel
+    let date: Date
 
     var body: some View {
         VStack (spacing: 15){
@@ -61,7 +62,7 @@ struct ProfileHeaderView: View {
                     Task {
                         do {
                             try await AuthService.shared.removeUserIdFromFirestore(viewModel.user.id)
-                            UserDefaultsManager.shared.storeReceivedUserId(viewModel.user.id)
+                            RealmManager.shared.storeData(viewModel.user.id, date: date)
 
                         } catch {
                             // エラーハンドリング
@@ -81,8 +82,8 @@ struct ProfileHeaderView: View {
                     Button(action: {
                         Task {
                             do {
-                                UserDefaultsManager.shared.removeUserID(viewModel.user.id)
-                                try await AuthService.shared.addUserIdToFirestore(viewModel.user.id)
+                                RealmManager.shared.removeData(viewModel.user.id)
+                                try await AuthService.shared.addUserIdToFirestore(viewModel.user.id, date)
 
                             } catch {
                                 // エラーハンドリング
@@ -101,8 +102,11 @@ struct ProfileHeaderView: View {
                     })
 
                     Button(action: {
-                        UserDefaultsManager.shared.removeUserID(viewModel.user.id)
-
+                        RealmManager.shared.storeData(viewModel.user.id, date: date)
+                        //TODO: deletefirestore
+                        Task {
+                            try await AuthService.shared.removeUserIdFromFirestore(viewModel.user.id)
+                        }
                     }, label: {
                         Image(systemName: "hand.wave.fill")
                             .foregroundStyle(.white)
@@ -117,5 +121,5 @@ struct ProfileHeaderView: View {
 }//view
 
 #Preview {
-    ProfileHeaderView(viewModel: ProfileViewModel(user: User.MOCK_USERS[1], currentUser: User.MOCK_USERS[0]))
+    ProfileHeaderView(viewModel: ProfileViewModel(user: User.MOCK_USERS[1], currentUser: User.MOCK_USERS[0]), date: Date())
 }

--- a/NearU/View/Profile/View/ProfileView.swift
+++ b/NearU/View/Profile/View/ProfileView.swift
@@ -11,21 +11,23 @@ struct ProfileView: View {
     //MARK: - property
     @StateObject var viewModel: ProfileViewModel
 
-    init(user: User, currentUser: User) {
+    let date: Date
+
+    init(user: User, currentUser: User, date: Date) {
         _viewModel = StateObject(wrappedValue: ProfileViewModel(user: user, currentUser: currentUser))
+        self.date = date
     }
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack {
                 //header
-                ProfileHeaderView(viewModel: viewModel)
+                ProfileHeaderView(viewModel: viewModel, date: date)
 
                 Divider()
                 //link scroll view
 
                 if !viewModel.user.isPrivate || viewModel.currentUser.connectList.contains(viewModel.user.id) && viewModel.user.connectList.contains(viewModel.currentUser.id){
-
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: 5) {
                             ForEach (Array(viewModel.user.snsLinks.keys), id: \.self) { key in
@@ -58,5 +60,5 @@ struct ProfileView: View {
 }//view
 
 #Preview {
-    ProfileView(user: User.MOCK_USERS[0], currentUser: User.MOCK_USERS[1])
+    ProfileView(user: User.MOCK_USERS[0], currentUser: User.MOCK_USERS[1], date: Date())
 }

--- a/NearU/View/Search/View/ConnectedSearchView.swift
+++ b/NearU/View/Search/View/ConnectedSearchView.swift
@@ -21,23 +21,23 @@ struct ConnectedSearchView: View {
         NavigationStack {
             ScrollView {
                 LazyVStack (spacing: 16){
-                    if viewModel.connectedUsers.isEmpty {
+                    if viewModel.userDatePairs.isEmpty {
                         Text("承認したユーザーがいません")
                             .font(.footnote)
                             .fontWeight(.bold)
                             .foregroundColor(.gray)
                             .padding()
                     } else {
-                        ForEach(viewModel.connectedUsers) { user in
-                            NavigationLink(value: user) {
+                        ForEach(viewModel.userDatePairs, id: \.self) { pair in
+                            NavigationLink(value: pair ) {
                                 HStack {
-                                    CircleImageView(user: user, size: .xsmall, borderColor: .clear)
+                                    CircleImageView(user: pair.user, size: .xsmall, borderColor: .clear)
                                     VStack (alignment: .leading){
-                                        Text(user.username)
+                                        Text(pair.user.username)
                                             .fontWeight(.bold)
                                             .foregroundStyle(Color.primary)
 
-                                        if let fullname = user.fullname { //fullnameがnilじゃないなら
+                                        if let fullname = pair.user.fullname { //fullnameがnilじゃないなら
                                             Text(fullname)
                                                 .foregroundStyle(Color.primary)
                                         }
@@ -59,8 +59,8 @@ struct ConnectedSearchView: View {
             .refreshable {
                 print("refresh")
             }
-            .navigationDestination(for: User.self, destination: { value in
-                ProfileView(user: value, currentUser: currentUser)
+            .navigationDestination(for: UserDatePair.self, destination: { pair in
+                ProfileView(user: pair.user, currentUser: currentUser, date: pair.date)
             })
         }//navigationstack
     }

--- a/NearU/View/Search/View/WaitingSearchView.swift
+++ b/NearU/View/Search/View/WaitingSearchView.swift
@@ -31,16 +31,16 @@ struct WaitingSearchView: View {
                             .foregroundColor(.gray)
                             .padding()
                     } else {
-                        ForEach(viewModel.userDatePairs, id: \.0.id) { user, date in
-                            NavigationLink(value: user) {
+                        ForEach(viewModel.userDatePairs, id: \.self) { pair in
+                            NavigationLink(value: pair) {
                                 HStack {
-                                    CircleImageView(user: user, size: .xsmall, borderColor: .clear)
+                                    CircleImageView(user: pair.user, size: .xsmall, borderColor: .clear)
                                     VStack(alignment: .leading) {
-                                        Text(user.username)
+                                        Text(pair.user.username)
                                             .fontWeight(.bold)
                                             .foregroundStyle(Color.primary)
 
-                                        if let fullname = user.fullname {
+                                        if let fullname = pair.user.fullname {
                                             Text(fullname)
                                                 .foregroundStyle(Color.primary)
                                         }
@@ -49,15 +49,15 @@ struct WaitingSearchView: View {
 
                                     Spacer()
 
-                                    Text("\(dateFormatter.string(from: date))")
+                                    Text("\(dateFormatter.string(from: pair.date))")
                                         .font(.caption)
                                         .foregroundColor(.gray)
 
                                     Button(action: {
                                         Task {
                                             do {
-                                                try await AuthService.shared.addUserIdToFirestore(user.id)
-                                                RealmManager.shared.removeData(user.id)
+                                                try await AuthService.shared.addUserIdToFirestore(pair.user.id, pair.date)
+                                                RealmManager.shared.removeData(pair.user.id)
                                                 // デバッグ
                                                 let storedUserIds = RealmManager.shared.getUserIDs()
                                                 print("Stored User IDs after removal: \(storedUserIds)")
@@ -77,7 +77,7 @@ struct WaitingSearchView: View {
                                     })
 
                                     Button(action: {
-                                        RealmManager.shared.removeData(user.id)
+                                        RealmManager.shared.removeData(pair.user.id)
                                     }, label: {
                                         Image(systemName: "hand.wave.fill")
                                             .foregroundStyle(.white)
@@ -97,8 +97,8 @@ struct WaitingSearchView: View {
             .refreshable {
                 print("refresh")
             }
-            .navigationDestination(for: User.self, destination: { value in
-                ProfileView(user: value, currentUser: currentUser)
+            .navigationDestination(for: UserDatePair.self, destination: { pair in
+                ProfileView(user: pair.user, currentUser: currentUser, date: pair.date)
             })
         } // NavigationStack
     }

--- a/NearU/View/Search/ViewModel/ConnectedSearchViewModel.swift
+++ b/NearU/View/Search/ViewModel/ConnectedSearchViewModel.swift
@@ -12,46 +12,48 @@ import Firebase
 class ConnectedSearchViewModel: ObservableObject {
     //MARK: - property
     let currentUser: User
+    @Published var userDatePairs = [UserDatePair]()
     @Published var connectedUsers = [User]() // User型の空の配列を作成
     private var listener: ListenerRegistration?
 
     //MARK: - init
     init(currentUser: User) {
         self.currentUser = currentUser
-        fetchConnectedUsers()
         listenForUpdates()
+
+        Task {
+            await fetchConnectedUsers()
+        }
     }
 
     //MARK: - func
-    func fetchConnectedUsers() {
-        Task {
-            do {
-                let users = try await UserService.fetchConnectedUsers(withUid: currentUser.id)
-                //メインスレッドで実行する必要がある
-                await MainActor.run {
-                    self.connectedUsers = users
-                }
-            } catch {
-                print("Error fetching connected users: \(error)")
+    func fetchConnectedUsers() async {
+        do {
+            let users = try await UserService.fetchConnectedUsers(documentId: currentUser.id)
+            //メインスレッドで実行する必要がある
+            await MainActor.run {
+                self.userDatePairs = users
             }
+        } catch {
+            print("Error fetching connected users: \(error)")
         }
     }
 
     func listenForUpdates() {
-        listener = Firestore.firestore().collection("users").document(currentUser.id)
-            .addSnapshotListener { [weak self] documentSnapshot, error in
+        listener = Firestore.firestore().collection("users").document(currentUser.id).collection("connectList")
+            .addSnapshotListener { [weak self] querySnapshot, error in
                 guard let self = self else { return }
                 if let error = error {
                     print("Error listening for updates: \(error)")
                     return
                 }
-                guard let document = documentSnapshot else {
-                    print("Document data was empty.")
+                guard let _ = querySnapshot else {
+                    print("QuerySnapshot data was empty.")
                     return
                 }
-                // ドキュメントのデコードが成功したかどうかを確認
-                if (try? document.data(as: User.self)) != nil {
-                    self.fetchConnectedUsers() // ドキュメントの変更を検出したら再読み込み
+                // ドキュメントに変更があれば fetchConnectedUsers() を実行
+                Task {
+                    await self.fetchConnectedUsers()
                 }
             }
     }

--- a/NearU/View/Search/ViewModel/SearchViewModel.swift
+++ b/NearU/View/Search/ViewModel/SearchViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @MainActor
 class SearchViewModel: ObservableObject {
-    @Published var userDatePairs = [(User, Date)]()
+    @Published var userDatePairs = [UserDatePair]()
     private var cancellables = Set<AnyCancellable>()
 
     init() {
@@ -28,7 +28,8 @@ class SearchViewModel: ObservableObject {
             let userIds = encountDataList.map { $0.userId }
             let dates = encountDataList.map { $0.date }
             let users = try await UserService.fetchWaitingUsers(userIds)
-            self.userDatePairs = Array(zip(users, dates))
+            // ユーザーと日付を UserDatePair に変換
+            self.userDatePairs = zip(users, dates).map { UserDatePair(user: $0, date: $1) }
         } catch {
             print("Error fetching users: \(error)")
         }


### PR DESCRIPTION
## 概要
connectListの参照先をサブコレクションにした際のデータの保存，削除，フェッチを適切に処理するための修正

## 追加・変更点
・User型とDate型をプロパティにもつUserDatePair構造体を新たに作成
・承認ユーザーリストや相手のユーザープロフィールにすれちがった時の時間を格納するプロパティを追加
・usersコレクションのドキュメントフィールドから，connectListサブコレクションのドキュメントフィールドを参照するように変更
・すれちがったユーザーを保存するローカルデータベースとしてUserDefaultsではなくRealmへ完全移行