### PR TITLE
パスワードリセット機能の実装と新規登録のUI修正

### DIFF
--- a/NearU/Authentication/View/AddEmailView.swift
+++ b/NearU/Authentication/View/AddEmailView.swift
@@ -13,12 +13,12 @@ struct AddEmailView: View {
 
     var body: some View {
         VStack (spacing: 10) {
-            Text("Add your email")
+            Text("メールアドレスを設定")
                 .font(.title2)
                 .fontWeight(.bold)
                 .padding(.top)
 
-            Text("You'll use this email to signIn to your account")
+            Text("サインインにこのメールアドレスを使用します。")
                 .font(.footnote)
                 .foregroundStyle(.gray)
                 .multilineTextAlignment(.center)
@@ -26,9 +26,8 @@ struct AddEmailView: View {
                 .padding(.bottom)
 
 
-            TextField("Email", text: $viewModel.email)
-                .autocapitalization(.none) //自動的に大文字にしない
-                .modifier(IGTextFieldModifier()) //カスタムモディファイア
+            TextField("メールアドレス", text: $viewModel.email)
+                .modifier(IGTextFieldModifier())
 
             NavigationLink {
                 CreateUserNameView()

--- a/NearU/Authentication/View/CreatePasswordView.swift
+++ b/NearU/Authentication/View/CreatePasswordView.swift
@@ -13,12 +13,12 @@ struct CreatePasswordView: View {
 
     var body: some View {
         VStack (spacing: 10) {
-            Text("Create Password")
+            Text("パスワードを設定")
                 .font(.title2)
                 .fontWeight(.bold)
                 .padding(.top)
 
-            Text("Your password must be at least 6 characters in length")
+            Text("6文字以上のパスワードを入力してください。")
                 .font(.footnote)
                 .foregroundStyle(.gray)
                 .multilineTextAlignment(.center)
@@ -26,8 +26,7 @@ struct CreatePasswordView: View {
                 .padding(.bottom)
 
 
-            TextField("Password", text: $viewModel.password)
-                .autocapitalization(.none) //自動的に大文字にしない
+            TextField("パスワード", text: $viewModel.password)
                 .modifier(IGTextFieldModifier())
 
             NavigationLink {

--- a/NearU/Authentication/View/CreateUserNameView.swift
+++ b/NearU/Authentication/View/CreateUserNameView.swift
@@ -13,12 +13,12 @@ struct CreateUserNameView: View {
 
     var body: some View {
         VStack (spacing: 10) {
-            Text("Create username")
+            Text("ユーザ名を設定")
                 .font(.title2)
                 .fontWeight(.bold)
                 .padding(.top)
 
-            Text("Pick a username for your new account. You can always charge it")
+            Text("他のユーザに公開される名前です。いつでも変更ができます。")
                 .font(.footnote)
                 .foregroundStyle(.gray)
                 .multilineTextAlignment(.center)
@@ -26,9 +26,8 @@ struct CreateUserNameView: View {
                 .padding(.bottom)
 
 
-            TextField("Username", text: $viewModel.username)
-                .autocapitalization(.none) //自動的に大文字にしない
-                .modifier(IGTextFieldModifier()) //カスタムモディファイア
+            TextField("ユーザ名", text: $viewModel.username)
+                .modifier(IGTextFieldModifier())
 
             NavigationLink {
                 CreatePasswordView()

--- a/NearU/Authentication/View/LoginView.swift
+++ b/NearU/Authentication/View/LoginView.swift
@@ -42,11 +42,16 @@ struct LoginView: View {
                 Button(action: {
                     print("show forgot password")
                 }, label: {
-                    Text("パスワードを忘れた場合")
-                        .font(.footnote)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(Color(.systemMint))
-                        .padding(.top)
+                    NavigationLink {
+                        PasswordResetView()
+                            .navigationBarBackButtonHidden()
+                    } label: {
+                        Text("パスワードを忘れた場合")
+                            .font(.footnote)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(Color(.systemMint))
+                            .padding(.top)
+                    }
                 })
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.trailing)

--- a/NearU/Authentication/View/PasswordResetView.swift
+++ b/NearU/Authentication/View/PasswordResetView.swift
@@ -1,0 +1,109 @@
+//
+//  PasswordResetView.swift
+//  NearU
+//
+//  Created by Tsubasa Watanabe on 2024/10/25.
+//
+
+import SwiftUI
+
+struct PasswordResetView: View {
+    @Environment(\.dismiss) var dismiss
+    @StateObject private var viewModel = PasswordResetViewModel()
+    @State private var message: String? = nil
+    @State private var showSendButton: Bool = true
+    @State private var showResendButton: Bool = false
+    
+    var body: some View {
+        VStack (spacing: 10) {
+            Text("パスワードの再設定")
+                .font(.title2)
+                .fontWeight(.bold)
+                .padding(.top)
+            
+            Text("パスワードを再設定するためのリンクをメールで送信します。")
+                .font(.footnote)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+                .padding(.bottom)
+            
+            TextField("メールアドレス", text: $viewModel.email)
+                .modifier(IGTextFieldModifier())
+            
+            if let message = message {
+                Text(message)
+                    .foregroundColor(.red)
+                    .font(.footnote)
+                    .padding(.top)
+                    .transition(.opacity)
+            }
+            
+            // 送信ボタン
+            if showSendButton {
+                Button(action: {
+                    showSendButton = false
+                    Task {
+                        do {
+                            try await viewModel.resetPassword()
+                            message = "リセット用のリンクを送信しました。"
+                            showResendButton = true
+                        } catch {
+                            message = "エラーが発生しました。もう一度お試しください。"
+                            showSendButton = true
+                        }
+                    }
+                }, label: {
+                    Text("送信")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                        .frame(width: 360, height: 44)
+                        .background(Color(.systemMint))
+                        .cornerRadius(12)
+                        .padding(.top)
+                })
+            }
+            
+            // 再送信ボタン
+            if showResendButton {
+                Button(action: {
+                    Task {
+                        do {
+                            try await viewModel.resetPassword()
+                            message = "リセット用のリンクを再送信しました。"
+                        } catch {
+                            message = "再送信に失敗しました。もう一度お試しください。"
+                        }
+                    }
+                }, label: {
+                    Text("再送信")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                        .frame(width: 360, height: 44)
+                        .background(Color(.systemOrange))
+                        .cornerRadius(12)
+                        .padding(.top)
+                })
+            }
+            
+            Spacer()
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Image(systemName: "chevron.left")
+                    .imageScale(.large)
+                    .onTapGesture {
+                        dismiss()
+                    }
+            }
+        }
+    }
+}
+
+#Preview {
+    PasswordResetView()
+}
+
+

--- a/NearU/Authentication/ViewModel/PasswordResetViewModel.swift
+++ b/NearU/Authentication/ViewModel/PasswordResetViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  PasswordResetViewModel.swift
+//  NearU
+//
+//  Created by Tsubasa Watanabe on 2024/10/25.
+//
+
+import Foundation
+
+class PasswordResetViewModel: ObservableObject {
+    @Published var email: String = ""
+    
+    func resetPassword() async throws {
+        guard !email.isEmpty else {
+            throw NSError(domain: "", code: 400, userInfo: [NSLocalizedDescriptionKey: "メールアドレスを入力してください。"])
+        }
+        try await AuthService.shared.resetPassword(withEmail: email)
+    }
+}

--- a/NearU/Modifier/IGTextFieldModifier.swift
+++ b/NearU/Modifier/IGTextFieldModifier.swift
@@ -11,6 +11,7 @@ struct IGTextFieldModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .textInputAutocapitalization(.never) // 自動で大文字にしない
+            .disableAutocorrection(true) // スペルチェックを無効にする
             .font(.subheadline)
             .padding(12)
             .background(Color(.systemGray6))

--- a/NearU/Service/AuthService.swift
+++ b/NearU/Service/AuthService.swift
@@ -32,6 +32,16 @@ class AuthService {
             throw error  // エラーを再スロー
         }
     }
+    
+    @MainActor
+    func resetPassword(withEmail email: String) async throws { //パスワードリセット
+        do {
+            try await Auth.auth().sendPasswordReset(withEmail: email)
+        } catch {
+            print("DEBUG: パスワードリセットに失敗しました。エラー: \(error.localizedDescription)")
+            throw error
+        }
+    }
 
     @MainActor
     // 新規ユーザを作成する関数


### PR DESCRIPTION
## 変更点
#### パスワードリセット機能の実装
+ firebaseのsendPasswordReset関数を使用した。
+ authserviceで関数の定義、PasswordResetViewModelで関数の呼び出しをした。
+ リセットを行うためのメールアドレスを送信するビューを新たに追加

#### 新規登録のビューを日本語にした
+ 勝手に大文字になる問題とスペルチェックによって赤線が表示される問題を解決