### PR TITLE
デバイス間のpush通知を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ fastlane/test_output
 UserInterfaceState.xcuserstate
 # GoogleService-Info.plist
 Package.resolved
+Private.json
 

--- a/GoogleService-Info.plist
+++ b/GoogleService-Info.plist
@@ -9,7 +9,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.wataru.NearU20240718</string>
+	<string>com.wataru.NearU</string>
 	<key>PROJECT_ID</key>
 	<string>nearu-46768</string>
 	<key>STORAGE_BUCKET</key>

--- a/NearU.xcodeproj/project.pbxproj
+++ b/NearU.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		63B650052B8DDDF700289469 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B650042B8DDDF700289469 /* HomeView.swift */; };
 		63B650072B8DDE9300289469 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B650062B8DDE9300289469 /* ProfileView.swift */; };
 		63B6500B2B8DDF0200289469 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B6500A2B8DDF0200289469 /* SettingView.swift */; };
+		63BEA4942CD0B46A006382AF /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BEA4932CD0B46A006382AF /* NotificationManager.swift */; };
+		63BEA4962CD1CE3C006382AF /* FCMMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BEA4952CD1CE3C006382AF /* FCMMessage.swift */; };
 		63DFF87D2BF5930300A6DFB8 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 63DFF87C2BF5930300A6DFB8 /* FirebaseAnalytics */; };
 		63DFF8802BF6F02A00A6DFB8 /* ProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFF87F2BF6F02A00A6DFB8 /* ProfileHeaderView.swift */; };
 		63DFF8822BF6F14100A6DFB8 /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFF8812BF6F14100A6DFB8 /* EditProfileView.swift */; };
@@ -129,6 +131,8 @@
 		63B650042B8DDDF700289469 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		63B650062B8DDE9300289469 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		63B6500A2B8DDF0200289469 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
+		63BEA4932CD0B46A006382AF /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		63BEA4952CD1CE3C006382AF /* FCMMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMMessage.swift; sourceTree = "<group>"; };
 		63DFF87F2BF6F02A00A6DFB8 /* ProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderView.swift; sourceTree = "<group>"; };
 		63DFF8812BF6F14100A6DFB8 /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
 		63DFF8832BF6F1C000A6DFB8 /* CurrentUserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserProfileViewModel.swift; sourceTree = "<group>"; };
@@ -175,6 +179,7 @@
 				63DFF8C22C05B60300A6DFB8 /* BLEPeripheralManager.swift */,
 				63173DF52C36BEC700F1FE82 /* UserDefaultsManager.swift */,
 				63135DA22CB7ABCC004137AF /* RealmManager.swift */,
+				63BEA4932CD0B46A006382AF /* NotificationManager.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -219,6 +224,7 @@
 				637B972B2CBA070D00EFB09F /* EncountDataStruct.swift */,
 				63AEA5CA2CC4053C009A22A2 /* Tags.swift */,
 				63AEA5CC2CC66B18009A22A2 /* UserDatePair.swift */,
+				63BEA4952CD1CE3C006382AF /* FCMMessage.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -525,9 +531,11 @@
 				638732172BF4B4630099F68A /* AuthService.swift in Sources */,
 				637B972C2CBA070D00EFB09F /* EncountDataStruct.swift in Sources */,
 				63AEF0FD2C0C507300DE196E /* WaitingSearchView.swift in Sources */,
+				63BEA4942CD0B46A006382AF /* NotificationManager.swift in Sources */,
 				63DFF8842BF6F1C000A6DFB8 /* CurrentUserProfileViewModel.swift in Sources */,
 				638732192BF4B62B0099F68A /* LoginViewModel.swift in Sources */,
 				63B650072B8DDE9300289469 /* ProfileView.swift in Sources */,
+				63BEA4962CD1CE3C006382AF /* FCMMessage.swift in Sources */,
 				63B64FE62B8C797400289469 /* BLECentralManager.swift in Sources */,
 				630B9EA62CC345B4002F06AB /* EditTagsView.swift in Sources */,
 				63DFF88C2BF8760B00A6DFB8 /* SearchView.swift in Sources */,

--- a/NearU.xcodeproj/project.pbxproj
+++ b/NearU.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		63135DA32CB7ABCC004137AF /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63135DA22CB7ABCC004137AF /* RealmManager.swift */; };
 		63173DF62C36BEC700F1FE82 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63173DF52C36BEC700F1FE82 /* UserDefaultsManager.swift */; };
 		63173DF82C37D77600F1FE82 /* AddLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63173DF72C37D77600F1FE82 /* AddLinkView.swift */; };
+		6375622C2CCE50B100137B27 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 6375622B2CCE50B100137B27 /* FirebaseMessaging */; };
 		637B97272CB8FBC100EFB09F /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 637B97262CB8FBC100EFB09F /* RealmSwift */; };
 		637B97282CB9024400EFB09F /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 637B97262CB8FBC100EFB09F /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		637B972C2CBA070D00EFB09F /* EncountDataStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637B972B2CBA070D00EFB09F /* EncountDataStruct.swift */; };
@@ -94,6 +95,7 @@
 		63135DA22CB7ABCC004137AF /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
 		63173DF52C36BEC700F1FE82 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		63173DF72C37D77600F1FE82 /* AddLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkView.swift; sourceTree = "<group>"; };
+		6375622A2CCC83C900137B27 /* NearU.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NearU.entitlements; sourceTree = "<group>"; };
 		637B972B2CBA070D00EFB09F /* EncountDataStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncountDataStruct.swift; sourceTree = "<group>"; };
 		637BA0582C4252D200368566 /* AddLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkViewModel.swift; sourceTree = "<group>"; };
 		637BA05A2C43934600368566 /* SNSLinkButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSLinkButtonView.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6375622C2CCE50B100137B27 /* FirebaseMessaging in Frameworks */,
 				637B97272CB8FBC100EFB09F /* RealmSwift in Frameworks */,
 				63DFF8972BFC99ED00A6DFB8 /* Kingfisher in Frameworks */,
 				63E4CC8A2BED30EA009E0C9B /* FirebaseAuth in Frameworks */,
@@ -295,6 +298,7 @@
 		63B64FD62B8C763900289469 /* NearU */ = {
 			isa = PBXGroup;
 			children = (
+				6375622A2CCC83C900137B27 /* NearU.entitlements */,
 				63B64FE72B8C7BF200289469 /* Info.plist */,
 				63B64FD72B8C763900289469 /* NearUApp.swift */,
 				6367B7922BE149DF0065C1BD /* Main */,
@@ -441,6 +445,7 @@
 				63DFF8962BFC99ED00A6DFB8 /* Kingfisher */,
 				63135D8A2CA6643F004137AF /* FirebaseAppCheck */,
 				637B97262CB8FBC100EFB09F /* RealmSwift */,
+				6375622B2CCE50B100137B27 /* FirebaseMessaging */,
 			);
 			productName = NearU;
 			productReference = 63B64FD42B8C763900289469 /* NearU.app */;
@@ -682,10 +687,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_ENTITLEMENTS = NearU/NearU.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"NearU/Preview Content\"";
-				DEVELOPMENT_TEAM = 9YCLAPV5D5;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = NQD3LAN9FK;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NearU/Info.plist;
@@ -702,8 +710,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wataru.NearU20241007;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wataru.NearU;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Chonnect;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -715,11 +725,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = NearU/NearU.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"NearU/Preview Content\"";
-				DEVELOPMENT_TEAM = 9YCLAPV5D5;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = NQD3LAN9FK;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NearU/Info.plist;
@@ -736,9 +749,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wataru.NearU20241007;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wataru.NearU;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Chonnect;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -800,6 +814,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 63E4CC882BED30EA009E0C9B /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAppCheck;
+		};
+		6375622B2CCE50B100137B27 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 63E4CC882BED30EA009E0C9B /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 		637B97262CB8FBC100EFB09F /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/NearU.xcodeproj/project.pbxproj
+++ b/NearU.xcodeproj/project.pbxproj
@@ -812,7 +812,7 @@
 			repositoryURL = "https://github.com/vapor/jwt-kit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.1.0;
+				minimumVersion = 4.0.0;
 			};
 		};
 		63DFF8952BFC99ED00A6DFB8 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/NearU.xcodeproj/project.pbxproj
+++ b/NearU.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		63B6500B2B8DDF0200289469 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B6500A2B8DDF0200289469 /* SettingView.swift */; };
 		63BEA4942CD0B46A006382AF /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BEA4932CD0B46A006382AF /* NotificationManager.swift */; };
 		63BEA4962CD1CE3C006382AF /* FCMMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BEA4952CD1CE3C006382AF /* FCMMessage.swift */; };
+		63BEA49A2CD21E04006382AF /* Private.json in Resources */ = {isa = PBXBuildFile; fileRef = 63BEA4992CD21E04006382AF /* Private.json */; };
+		63BEA49D2CD2211A006382AF /* JWTKit in Frameworks */ = {isa = PBXBuildFile; productRef = 63BEA49C2CD2211A006382AF /* JWTKit */; };
 		63DFF87D2BF5930300A6DFB8 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 63DFF87C2BF5930300A6DFB8 /* FirebaseAnalytics */; };
 		63DFF8802BF6F02A00A6DFB8 /* ProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFF87F2BF6F02A00A6DFB8 /* ProfileHeaderView.swift */; };
 		63DFF8822BF6F14100A6DFB8 /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFF8812BF6F14100A6DFB8 /* EditProfileView.swift */; };
@@ -133,6 +135,7 @@
 		63B6500A2B8DDF0200289469 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		63BEA4932CD0B46A006382AF /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		63BEA4952CD1CE3C006382AF /* FCMMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMMessage.swift; sourceTree = "<group>"; };
+		63BEA4992CD21E04006382AF /* Private.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Private.json; sourceTree = "<group>"; };
 		63DFF87F2BF6F02A00A6DFB8 /* ProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderView.swift; sourceTree = "<group>"; };
 		63DFF8812BF6F14100A6DFB8 /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
 		63DFF8832BF6F1C000A6DFB8 /* CurrentUserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserProfileViewModel.swift; sourceTree = "<group>"; };
@@ -159,6 +162,7 @@
 				63DFF8972BFC99ED00A6DFB8 /* Kingfisher in Frameworks */,
 				63E4CC8A2BED30EA009E0C9B /* FirebaseAuth in Frameworks */,
 				63E4CC902BED30EA009E0C9B /* FirebaseStorage in Frameworks */,
+				63BEA49D2CD2211A006382AF /* JWTKit in Frameworks */,
 				63E4CC8C2BED30EA009E0C9B /* FirebaseFirestore in Frameworks */,
 				63135D8B2CA6643F004137AF /* FirebaseAppCheck in Frameworks */,
 				63DFF87D2BF5930300A6DFB8 /* FirebaseAnalytics in Frameworks */,
@@ -304,6 +308,7 @@
 		63B64FD62B8C763900289469 /* NearU */ = {
 			isa = PBXGroup;
 			children = (
+				63BEA4992CD21E04006382AF /* Private.json */,
 				6375622A2CCC83C900137B27 /* NearU.entitlements */,
 				63B64FE72B8C7BF200289469 /* Info.plist */,
 				63B64FD72B8C763900289469 /* NearUApp.swift */,
@@ -452,6 +457,7 @@
 				63135D8A2CA6643F004137AF /* FirebaseAppCheck */,
 				637B97262CB8FBC100EFB09F /* RealmSwift */,
 				6375622B2CCE50B100137B27 /* FirebaseMessaging */,
+				63BEA49C2CD2211A006382AF /* JWTKit */,
 			);
 			productName = NearU;
 			productReference = 63B64FD42B8C763900289469 /* NearU.app */;
@@ -485,6 +491,7 @@
 				63E4CC882BED30EA009E0C9B /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				63DFF8952BFC99ED00A6DFB8 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				637B97252CB8FBC100EFB09F /* XCRemoteSwiftPackageReference "realm-swift" */,
+				63BEA49B2CD2211A006382AF /* XCRemoteSwiftPackageReference "jwt-kit" */,
 			);
 			productRefGroup = 63B64FD52B8C763900289469 /* Products */;
 			projectDirPath = "";
@@ -503,6 +510,7 @@
 				63B64FDF2B8C763A00289469 /* Preview Assets.xcassets in Resources */,
 				63B64FDC2B8C763A00289469 /* Assets.xcassets in Resources */,
 				63E4CC872BED3037009E0C9B /* GoogleService-Info.plist in Resources */,
+				63BEA49A2CD21E04006382AF /* Private.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -799,6 +807,14 @@
 				kind = branch;
 			};
 		};
+		63BEA49B2CD2211A006382AF /* XCRemoteSwiftPackageReference "jwt-kit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/vapor/jwt-kit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.0;
+			};
+		};
 		63DFF8952BFC99ED00A6DFB8 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
@@ -832,6 +848,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 637B97252CB8FBC100EFB09F /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = RealmSwift;
+		};
+		63BEA49C2CD2211A006382AF /* JWTKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 63BEA49B2CD2211A006382AF /* XCRemoteSwiftPackageReference "jwt-kit" */;
+			productName = JWTKit;
 		};
 		63DFF87C2BF5930300A6DFB8 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/NearU.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NearU.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "517ef998cb25ad15eb565382a474e9353087be7c02a3aa7fa49c04f8a30d2f15",
+  "originHash" : "a37883224db9164e73030030616f3d588349840b9af4e6fa4d368251b8d7ff34",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -83,6 +83,15 @@
       }
     },
     {
+      "identity" : "jwt-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/jwt-kit.git",
+      "state" : {
+        "revision" : "02a0fa600eee1bdc892013d62fc795fc623a5cc3",
+        "version" : "5.1.0"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
@@ -134,6 +143,42 @@
       "state" : {
         "branch" : "master",
         "revision" : "02860d17d793e0d4f9c08ed937002d80e09fdffd"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "1fbb6ef21f1525ed5faf4c95207b9c11bea27e94",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "8fa345c2081cfbd4851dffff5dd5bed48efe6081",
+        "version" : "3.9.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {

--- a/NearU.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NearU.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a37883224db9164e73030030616f3d588349840b9af4e6fa4d368251b8d7ff34",
+  "originHash" : "bf2ed194e5bb6cb189301e98d34f9ef8c38174d9cbeabefc36d0c1765bf83dfe",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/jwt-kit.git",
       "state" : {
-        "revision" : "02a0fa600eee1bdc892013d62fc795fc623a5cc3",
-        "version" : "5.1.0"
+        "revision" : "c2595b9ad7f512d7f334830b4df1fed6e917946a",
+        "version" : "4.13.4"
       }
     },
     {
@@ -155,30 +155,12 @@
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "1fbb6ef21f1525ed5faf4c95207b9c11bea27e94",
-        "version" : "1.6.1"
-      }
-    },
-    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
         "revision" : "8fa345c2081cfbd4851dffff5dd5bed48efe6081",
         "version" : "3.9.0"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
-        "version" : "1.6.1"
       }
     },
     {

--- a/NearU/Info.plist
+++ b/NearU/Info.plist
@@ -2,16 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>INIntentsSupported</key>
-    <array>
-        <string>Intent</string>
-    </array>
-    <key>UIBackgroundModes</key>
-    <array>
-        <string>bluetooth-central</string>
-        <string>bluetooth-peripheral</string>
-    </array>
-    <key>NSBluetoothAlwaysUsageDescription</key>
-    <string>このアプリはBLE通信を使用します。</string>
+	<key>INIntentsSupported</key>
+	<array>
+		<string>Intent</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-central</string>
+		<string>bluetooth-peripheral</string>
+		<string>remote-notification</string>
+	</array>
+    <key>FirebaseAppDelegateProxyEnabled</key>
+    <false/>
 </dict>
 </plist>

--- a/NearU/Model/FCMMessage.swift
+++ b/NearU/Model/FCMMessage.swift
@@ -1,0 +1,28 @@
+//
+//  FCMMessage.swift
+//  NearU
+//
+//  Created by  髙橋和 on 2024/10/30.
+//
+
+import Foundation
+
+struct FCMMessage: Codable {
+    struct Message: Codable {
+        let token: String
+        let notification: Notification
+        let data: Data
+    }
+
+    struct Notification: Codable {
+        let title: String
+        let body: String
+    }
+
+    struct Data: Codable {
+        let documentId: String
+        let date: String
+    }
+
+    let message: Message
+}

--- a/NearU/Model/User.swift
+++ b/NearU/Model/User.swift
@@ -21,6 +21,7 @@ struct User: Identifiable, Hashable, Codable {
     var isPrivate: Bool
     var connectList: [String]
     var snsLinks: [String: String]
+    var fcmtoken: String?
 
     var isCurrentUser: Bool {
         guard let currentUid = Auth.auth().currentUser?.uid else { return false } //現在のユーザ情報があればそれをcurrentUidに格納

--- a/NearU/NearU.entitlements
+++ b/NearU/NearU.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/NearU/NearUApp.swift
+++ b/NearU/NearUApp.swift
@@ -6,28 +6,30 @@
 //
 
 import SwiftUI
+import UserNotifications
 import Firebase
 import FirebaseCore
 import FirebaseAppCheck
+import FirebaseMessaging
 
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
     //アプリケーションの起動時に呼び出されるメソッド
     func application(_ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
 
         // プロバイダファクトリの宣言
         let providerFactory: AppCheckProviderFactory
 
         // ビルド設定に応じてプロバイダを切り替え
-        #if DEBUG
+#if DEBUG
         providerFactory = AppCheckDebugProviderFactory()
-        #else
+#else
         if #available(iOS 14.0, *) {
             providerFactory = AppAttestProviderFactory()
         } else {
             providerFactory = DeviceCheckProviderFactory()
         }
-        #endif
+#endif
 
         // App Checkのプロバイダを設定
         AppCheck.setAppCheckProviderFactory(providerFactory)
@@ -35,10 +37,88 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Firebaseの初期化
         FirebaseApp.configure()
 
+        // FCMトークンの取得やFirebaseのメッセージング関連のイベントをこのクラスで処理
+        Messaging.messaging().delegate = self
+
+        // アプリがフォアグラウンドで通知を受け取ったときの処理をこのクラスで行う
+        UNUserNotificationCenter.current().delegate = self
+
+        // Push通知許可のポップアップを表示
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { granted, _ in
+            guard granted else { return }
+            DispatchQueue.main.async {
+                application.registerForRemoteNotifications()
+            }
+        }
+
         return true
     }
 
-    //アプリケーションがバックグラウンドに移行する直前に呼ばれる
+    // テスト通知に必要なFCMトークンを出力する
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        print("didRegisterForRemoteNotificationsWithDeviceToken called")
+        Messaging.messaging().apnsToken = deviceToken
+        Messaging.messaging().token { token, error in
+            if let error = error {
+                print("Error fetching FCM registration token: \(error)")
+            } else if let token = token {
+                // UserDefaultsにFCMトークンを保存
+                UserDefaults.standard.set(token, forKey: "FCMToken")
+                // 保存が正常に完了したことを確認
+                if let savedToken = UserDefaults.standard.string(forKey: "FCMToken") {
+                    if savedToken == token {
+                        print("FCM token successfully saved to UserDefaults.")
+                    } else {
+                        print("FCM token saved to UserDefaults does not match the original token.")
+                    }
+                } else {
+                    print("Failed to retrieve FCM token from UserDefaults after saving.")
+                }
+            }
+        }
+    }
+
+    // Push通知の登録に失敗した場合に呼ばれる
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("Failed to register for remote notifications: \(error)")
+    }
+
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        if let messageID = userInfo["gcm.message_id"] {
+            print("MessageID: \(messageID)")
+        }
+        print(userInfo)
+        completionHandler(.newData)
+    }
+
+    // FCMトークンを受け取るデリゲートメソッド
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let fcmToken = fcmToken else { return }
+        print("messaging(_:didReceiveRegistrationToken:) called with token: \(fcmToken)")
+        // UserDefaultsにFCMトークンを保存
+        UserDefaults.standard.set(fcmToken, forKey: "FCMToken")
+        // 保存が正常に完了したことを確認
+        if let savedToken = UserDefaults.standard.string(forKey: "FCMToken") {
+            if savedToken == fcmToken {
+                print("FCM token successfully saved to UserDefaults.")
+            } else {
+                print("FCM token saved to UserDefaults does not match the original token.")
+            }
+        } else {
+            print("Failed to retrieve FCM token from UserDefaults after saving.")
+        }
+
+        // 必要に応じてトークンをサーバーに送信
+    }
+
+
+    // アプリがForeground時にPush通知を受信する処理
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound])
+    }
+
+    // アプリケーションがバックグラウンドに移行する直前に呼ばれる
     func applicationDidEnterBackground(_ application: UIApplication) {
         print("background")
         BLECentralManager.shared.stopScan()

--- a/NearU/Service/NotificationManager.swift
+++ b/NearU/Service/NotificationManager.swift
@@ -6,18 +6,21 @@
 //
 
 import Foundation
+import FirebaseMessaging
+import FirebaseFirestore
+import JWTKit
 
 class NotificationManager {
     static let shared = NotificationManager()
 
     func sendPushNotification(fcmToken: String, username: String, documentId: String, date: Date) async {
         // エンドポイントが正しいか確認
-        guard let url = URL(string: "https://fcm.googleapis.com/v1/projects/NearU/messages:send") else {
+        guard let url = URL(string: "https://fcm.googleapis.com/v1/projects/nearu-46768/messages:send") else {
             print("Invalid URL")
             return
         }
 
-        // 通知メッセージの作成
+        // 通知データの作成
         let dateString = "\(date.timeIntervalSince1970)"
         let notification = FCMMessage.Notification(title: "フォロー通知", body: "\(username)さんにフォローされました")
         let data = FCMMessage.Data(documentId: documentId, date: dateString)
@@ -31,16 +34,14 @@ class NotificationManager {
 
         // アクセストークンの取得
         var accessToken = ""
-        Task {
-            do {
-                accessToken = try await generateAccessToken()
-            } catch {
-                print("Failed to generate access token: \(error)")
-                return
-            }
+        do {
+            accessToken = try await generateAccessToken()
+        } catch {
+            print("Failed to generate access token: \(error)")
+            return
         }
-        // TODO: トークンを取得
 
+        // FCMに対する通知リクエストの設定
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -48,20 +49,111 @@ class NotificationManager {
         request.httpBody = jsonData
 
         // 指定されたURLにリクエストを送信
-        // データタスクの生成
-        URLSession.shared.dataTask(with: request) { data, response, error in
-            if let error = error {
-                print("Error: \(error.localizedDescription)")
-                return
-            }
-
+        // 非同期メソッドを使用してリクエストを送信
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
             if let httpResponse = response as? HTTPURLResponse {
                 print("Response: \(httpResponse.statusCode)")
+                if let responseBody = String(data: data, encoding: .utf8) {
+                    print("Response Body: \(responseBody)")
+                }
             }
-        }.resume() // resume()でデータタスクを実行
+        } catch {
+            print("Error sending push notification: \(error.localizedDescription)")
+        }
     }
 
     func generateAccessToken() async throws -> String {
-        return "dummy"
+        // Private.jsonを読み込む
+        guard let credentials = loadServiceAccountCredentials() else {
+            throw NSError(domain: "AccessTokenError", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to load service account credentials"])
+        }
+        // JWTの署名として利用
+        let privateKey = credentials.privateKey
+        let clientEmail = credentials.clientEmail
+
+        // JWTサイン用の署名者を初期化
+        let signer = JWTSigner.rs256(key: try .private(pem: privateKey))
+
+        // JWTのペイロードを作成
+        let payload = PayloadData(
+            iss: clientEmail,
+            scope: "https://www.googleapis.com/auth/firebase.messaging",
+            aud: "https://oauth2.googleapis.com/token",
+            exp: Date().addingTimeInterval(3600), // 1時間後に期限切れ
+            iat: Date()
+        )
+
+        // JWTトークンの生成
+        let jwt = try signer.sign(payload)
+
+        // JWTをアクセストークンに変換
+        // リクエストの設定
+        let url = URL(string: "https://oauth2.googleapis.com/token")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        // リクエストボディの設定
+        let body = "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=\(jwt)"
+        request.httpBody = body.data(using: .utf8)
+
+        // 非同期リクエストの送信とレスポンスの処理
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        // レスポンスの確認
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let responseBody = String(data: data, encoding: .utf8) ?? "No response body"
+            throw NSError(domain: "AccessTokenError", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to get access token: \(responseBody)"])
+        }
+
+        // アクセストークンの解析
+        if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+           let token = json["access_token"] as? String {
+            return token
+        } else {
+            let responseBody = String(data: data, encoding: .utf8) ?? "No response body"
+            throw NSError(domain: "AccessTokenError", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid access token response: \(responseBody)"])
+        }
+    }
+
+    func loadServiceAccountCredentials() -> (privateKey: String, clientEmail: String)? {
+        // アプリバンドル内のJSONファイルのURLを取得
+        guard let url = Bundle.main.url(forResource: "Private", withExtension: "json") else {
+            print("Failed to locate Private.json in app bundle")
+            return nil
+        }
+
+        // ファイルからデータを読み込む
+        guard let data = try? Data(contentsOf: url) else {
+            print("Failed to read data from service-account.json")
+            return nil
+        }
+        // JSONデータを解析
+        do {
+            if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+               let privateKey = json["private_key"] as? String,
+               let clientEmail = json["client_email"] as? String {
+                return (privateKey, clientEmail)
+            } else {
+                print("Invalid JSON structure in service-account.json")
+                return nil
+            }
+        } catch {
+            print("Error parsing JSON: \(error)")
+            return nil
+        }
+    }
+}
+
+struct PayloadData: JWTPayload {
+    let iss: String
+    let scope: String
+    let aud: String
+    let exp: Date
+    let iat: Date
+
+    func verify(using signer: JWTSigner) throws {
+        // 必要に応じて検証ロジックを実装
     }
 }

--- a/NearU/Service/NotificationManager.swift
+++ b/NearU/Service/NotificationManager.swift
@@ -1,0 +1,67 @@
+//
+//  NotificationManager.swift
+//  NearU
+//
+//  Created by  髙橋和 on 2024/10/29.
+//
+
+import Foundation
+
+class NotificationManager {
+    static let shared = NotificationManager()
+
+    func sendPushNotification(fcmToken: String, username: String, documentId: String, date: Date) async {
+        // エンドポイントが正しいか確認
+        guard let url = URL(string: "https://fcm.googleapis.com/v1/projects/NearU/messages:send") else {
+            print("Invalid URL")
+            return
+        }
+
+        // 通知メッセージの作成
+        let dateString = "\(date.timeIntervalSince1970)"
+        let notification = FCMMessage.Notification(title: "フォロー通知", body: "\(username)さんにフォローされました")
+        let data = FCMMessage.Data(documentId: documentId, date: dateString)
+        let message = FCMMessage.Message(token: fcmToken, notification: notification, data: data)
+        let fcmMessage = FCMMessage(message: message)
+
+        guard let jsonData = try? JSONEncoder().encode(fcmMessage) else {
+            print("Failed to create JSON data")
+            return
+        }
+
+        // アクセストークンの取得
+        var accessToken = ""
+        Task {
+            do {
+                accessToken = try await generateAccessToken()
+            } catch {
+                print("Failed to generate access token: \(error)")
+                return
+            }
+        }
+        // TODO: トークンを取得
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = jsonData
+
+        // 指定されたURLにリクエストを送信
+        // データタスクの生成
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                print("Error: \(error.localizedDescription)")
+                return
+            }
+
+            if let httpResponse = response as? HTTPURLResponse {
+                print("Response: \(httpResponse.statusCode)")
+            }
+        }.resume() // resume()でデータタスクを実行
+    }
+
+    func generateAccessToken() async throws -> String {
+        return "dummy"
+    }
+}

--- a/NearU/View/MainTabView.swift
+++ b/NearU/View/MainTabView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Firebase
 
 struct MainTabView: View {
     //MARK: - property
@@ -50,6 +51,10 @@ struct MainTabView: View {
             if peripheralManager.peripheralManager.state == .poweredOn {
                 peripheralManager.startAdvertising()
             }
+            // FCM トークンを Firestore に保存
+            if let fcmToken = UserDefaults.standard.string(forKey: "FCMToken") {
+                Task { await setFCMToken(fcmToken: fcmToken) }
+            }
         }
         .onChange(of: scenePhase) {
             switch scenePhase {
@@ -78,6 +83,26 @@ struct MainTabView: View {
             }
         }
     } //body
+
+    // FCMトークンをFirestoreに保存するメソッド
+    func setFCMToken(fcmToken: String) async {
+        guard let documentId = AuthService.shared.currentUser?.id else {
+            print("ユーザーがログインしていません")
+            return
+        }
+
+        let data: [String: Any] = [
+            "fcmtoken": fcmToken
+        ]
+
+        do {
+            try await Firestore.firestore().collection("users").document(documentId).updateData(data)
+            print("Document successfully updated with FCM token")
+        } catch {
+            print("Error updating document: \(error)")
+        }
+    }
+
 }//view
 
 #Preview {

--- a/NearU/View/Search/View/WaitingSearchView.swift
+++ b/NearU/View/Search/View/WaitingSearchView.swift
@@ -55,16 +55,7 @@ struct WaitingSearchView: View {
 
                                     Button(action: {
                                         Task {
-                                            do {
-                                                try await UserService.followUser(receivedId: pair.user.id, date: pair.date)
-                                                RealmManager.shared.removeData(pair.user.id)
-                                                // デバッグ
-                                                let storedUserIds = RealmManager.shared.getUserIDs()
-                                                print("Stored User IDs after removal: \(storedUserIds)")
-                                            } catch {
-                                                // エラーハンドリング
-                                                print("Error: \(error)")
-                                            }
+                                            await viewModel.handleFollowButton(currentUser: currentUser, pair: pair)
                                         }
                                     }, label: {
                                         Image(systemName: "figure.2")

--- a/NearU/View/Search/ViewModel/SearchViewModel.swift
+++ b/NearU/View/Search/ViewModel/SearchViewModel.swift
@@ -34,6 +34,28 @@ class SearchViewModel: ObservableObject {
             print("Error fetching users: \(error)")
         }
     }
+
+    func handleFollowButton(currentUser: User, pair: UserDatePair) async {
+        do {
+            try await UserService.followUser(receivedId: pair.user.id, date: pair.date)
+            RealmManager.shared.removeData(pair.user.id)
+            // デバッグ
+            let storedUserIds = RealmManager.shared.getUserIDs()
+            print("Stored User IDs after removal: \(storedUserIds)")
+
+            guard let fcmToken = pair.user.fcmtoken else { return }
+
+            await NotificationManager.shared.sendPushNotification(
+                fcmToken: fcmToken,
+                username: currentUser.username,
+                documentId: currentUser.id,
+                date: pair.date
+            )
+        } catch {
+            // エラーハンドリング
+            print("Error: \(error)")
+        }
+    }
 }
 
 


### PR DESCRIPTION
## 概要
フォローボタンを押すとpush通知が相手のスマホに届く機能を実装（不安定）

## 追加
・新しいパッケージの追加
・Usersドキュメントのフィールドにfcmtokenを追加

## 変更点
・Firebaesのメソッドスウィズを無効化
・gitignoreの編集
・BundleIDの変更（push通知を送るにはBundleIDがcom.wataru.NearUである必要がある）

