### PR TITLE
記事の編集

### DIFF
--- a/NearU/Service/UserService.swift
+++ b/NearU/Service/UserService.swift
@@ -69,20 +69,20 @@ struct UserService {
 
         return abstractUrls
     }
-    
-    static func deleteAbstractLink(userId: String, url: String) async throws {
-        let db = Firestore.firestore()
-        // URLが一致するドキュメントを取得して削除
-        let snapshot = try await db
-            .collection("users")
-            .document(userId)
-            .collection("abstract")
-            .whereField("abstract_url", isEqualTo: url)
-            .getDocuments()
-        
-        // 一致する各ドキュメントを削除
-        if let document = snapshot.documents.first {
-            try await document.reference.delete()
+
+    static func deleteArticleLink(url: String) async throws {
+        guard let documentId = AuthService.shared.currentUser?.id else { return }
+        let query = Firestore.firestore().collection("users").document(documentId).collection("abstract").whereField("abstract_url", isEqualTo: url)
+
+        // Firestoreから削除
+        do {
+            let snapshot = try await query.getDocuments()
+
+            if let document = snapshot.documents.first {
+                try await document.reference.delete()
+            }
+        } catch {
+            throw error
         }
     }
 

--- a/NearU/View/Profile/View/AddLinkView.swift
+++ b/NearU/View/Profile/View/AddLinkView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct AddLinkView: View {
     @State private var url = ""
     @State private var selectedSNS: String?
-    
+    @State private var articleUrls: [String] = [""]
+
     @Binding var isPresented: Bool
 
     @EnvironmentObject var viewModel: ArticleLinksViewModel
@@ -56,7 +57,6 @@ struct AddLinkView: View {
 
                                 Text(option.name)
                                     .foregroundStyle(option.color)
-
                             }
                             .tag(option.name)
                         }
@@ -71,16 +71,16 @@ struct AddLinkView: View {
                             .font(Font.subheadline)
                     }
                 })
-                
+
                 Section(content: {
 
-                    ForEach(viewModel.articleUrls.indices, id: \.self) { index in
-                        TextField("URLを入力", text: $viewModel.articleUrls[index])
+                    ForEach(articleUrls.indices, id: \.self) { index in
+                        TextField("URLを入力", text: $articleUrls[index])
                             .modifier(URLFieldModifier())
                     }
-                    
+
                     Button(action: {
-                        viewModel.articleUrls.append("") // ViewModelのurlsに追加
+                        articleUrls.append("")
                     }) {
                         HStack {
                             Image(systemName: "plus.circle")
@@ -95,20 +95,19 @@ struct AddLinkView: View {
                             .font(Font.subheadline)
                     }
                 })
-                
+
             } //form
             .navigationTitle("Add Link")
             .navigationBarItems(leading: Button("Cancel") {
                 isPresented = false
             }, trailing: Button("Done") {
                 Task {
-                    try await viewModel.addLink()
+                    try await viewModel.addLink(urls: articleUrls)
                     await viewModel.fetchArticleUrls()
                     try await AuthService.shared.loadUserData()
                     await MainActor.run {
                         isPresented = false
                     }
-
                 }
             })
         }//navigationstack

--- a/NearU/View/Profile/View/CurrentUserProfileView.swift
+++ b/NearU/View/Profile/View/CurrentUserProfileView.swift
@@ -123,7 +123,7 @@ struct CurrentUserProfileView: View {
                                     .padding()
                             } else {
                                 ForEach(articleLinksViewModel.openGraphData) { openGraphData in
-                                    SiteLinkButtonView(ogpData: openGraphData, showDeleteButton: false)
+                                    SiteLinkButtonView(ogpData: openGraphData, showDeleteButton: false, isOpenURL: true)
                                 }
                             }
                             VStack{
@@ -144,7 +144,8 @@ struct CurrentUserProfileView: View {
                             }
                             .padding(.bottom)
                             .sheet(isPresented: $showEditAbstract) {
-                                EditAbstractView(isPresented: $showEditAbstract, user: viewModel.user)
+                                EditAbstractView(isPresented: $showEditAbstract)
+                                    .environmentObject(articleLinksViewModel)
                             }
                         }
 

--- a/NearU/View/Profile/View/CurrentUserProfileView.swift
+++ b/NearU/View/Profile/View/CurrentUserProfileView.swift
@@ -26,7 +26,7 @@ struct CurrentUserProfileView: View {
         ZStack{
             Color(red: 0.96, green: 0.97, blue: 0.98)
                 .ignoresSafeArea()
-            
+
             VStack{
                 ScrollView(.vertical, showsIndicators: false){
                     VStack{
@@ -78,7 +78,7 @@ struct CurrentUserProfileView: View {
                             }
                         }//HStack
                         .padding(.bottom, 20)
-                        
+
                         ScrollView(.horizontal, showsIndicators: false) {
                            HStack {
                                if user.snsLinks.isEmpty {
@@ -91,7 +91,7 @@ struct CurrentUserProfileView: View {
                                            SNSLinkButtonView(selectedSNS: key, sns_url: url)
                                        }
                                    }
-                                   
+
                                    Button(action: {
                                        isAddingNewLink.toggle()
                                    }, label: {
@@ -123,7 +123,7 @@ struct CurrentUserProfileView: View {
                                     .padding()
                             } else {
                                 ForEach(articleLinksViewModel.openGraphData) { openGraphData in
-                                    SiteLinkButtonView(ogpData: openGraphData)
+                                    SiteLinkButtonView(ogpData: openGraphData, showDeleteButton: false)
                                 }
                             }
                             VStack{
@@ -149,7 +149,7 @@ struct CurrentUserProfileView: View {
                         }
 
                         Spacer()
-                        
+
                     }//VStack
                     .padding(.bottom, 100)
                     .fullScreenCover(isPresented: $showEditProfile) {

--- a/NearU/View/Profile/View/EditAbstractView.swift
+++ b/NearU/View/Profile/View/EditAbstractView.swift
@@ -1,99 +1,87 @@
 import SwiftUI
 
 struct EditAbstractView: View {
-    @State private var url = ""
-    @State private var selectedSNS: String?
-
+    @EnvironmentObject private var viewModel: ArticleLinksViewModel
+    @State private var articleUrls: [String] = [""]
     @Binding var isPresented: Bool
 
-    @StateObject var viewModel: AddLinkViewModel
-    @ObservedObject private var abstractModel = CurrentUserProfileViewModel()
-
-    init(isPresented: Binding<Bool>, user: User) {
-        self._isPresented = isPresented
-        self._viewModel = StateObject(wrappedValue: AddLinkViewModel(user: user))
-    }
-
     var body: some View {
-        Text("Hello, World!")
-//        NavigationStack {
-//            ZStack {
-//                Color(red: 0.96, green: 0.97, blue: 0.98) // シート全体の背景色
-//                    .ignoresSafeArea()
-//
-//                Form {
-//                    Section(content: {
-//                        ForEach(viewModel.urls.indices, id: \.self) { index in
-//                            TextField("URLを入力", text: $viewModel.urls[index])
-//                                .foregroundColor(Color(.systemMint))
-//                                .font(.system(size: 20, weight: .bold, design: .rounded))
-//                                .padding(10)
-//                                .cornerRadius(10)
-//                        }
-//
-//                        Button(action: {
-//                            viewModel.urls.append("") // ViewModelのurlsに追加
-//                        }) {
-//                            HStack {
-//                                Image(systemName: "plus.circle")
-//                                Text("URLを追加")
-//                                    .font(.system(size: 18, weight: .bold, design: .rounded))
-//                            }
-//                        }
-//                        .padding(.top, 10)
-//                    }, header: {
-//                        HStack {
-//                            Text("記事等のURLを追加する")
-//                                .font(Font.subheadline)
-//                        }
-//                    })
-//
-//                    Section {
-//                        VStack(alignment: .trailing, spacing: 20) {
-//                            if abstractModel.abstractUrls.isEmpty {
-//                                Text("リンクがありません")
-//                                    .foregroundColor(.orange)
-//                                    .padding()
-//                            } else {
-//                                ForEach(abstractModel.abstractUrls, id: \.self) { url in
-//                                    SiteLinkButtonView(
-//                                        abstract_url: url,
-//                                        showDeleteButton: true
-//                                    ) {
-//                                        deleteAbstract(url: url)
-//                                    }
-//                                }
-//                            }
-//                        }
-//                        .background(Color(red: 0.96, green: 0.97, blue: 0.98))
-//                    }
-//                } // Form
-//                .background(Color.clear)
-//            } // ZStack
-//            .navigationTitle("Edit abstract")
-//            .navigationBarItems(leading: Button("Cancel") {
-//                isPresented = false
-//            }, trailing: Button("Done") {
-//                Task {
-//                    try await viewModel.updateSNSLink()
-//                    try await AuthService.shared.loadUserData()
-//                    await MainActor.run {
-//                        isPresented = false
-//                    }
-//                }
-//            })
-//            .onAppear {
-//                Task {
-//                    await abstractModel.loadAbstractLinks()
-//                }
-//            }
-//        } // NavigationStack
+        NavigationStack {
+            Form {
+                Section {
+                    ForEach(articleUrls.indices, id: \.self) { index in
+                        TextField("URLを入力", text: $articleUrls[index])
+                            .modifier(URLFieldModifier())
+                    }
+
+                    Button {
+                        articleUrls.append("")
+                    } label: {
+                        HStack {
+                            Image(systemName: "plus.circle")
+                            Text("URLを追加")
+                                .font(.system(size: 10, weight: .bold))
+                        }
+                    }// label
+                } header: {
+                    Text("記事のURLを追加")
+                        .font(.footnote)
+                        .fontWeight(.bold)
+                        .offset(x: -15)
+                        .padding(.bottom, 10)
+                } //header
+
+                Section {
+                    if viewModel.openGraphData.isEmpty {
+                        Text("リンクがありません")
+                            .foregroundColor(.orange)
+                            .padding()
+                    } else {
+                        ForEach(viewModel.openGraphData) { openGraphData in
+                            SiteLinkButtonView(ogpData: openGraphData, showDeleteButton: true, isOpenURL: false)
+                                .environmentObject(viewModel)
+                        }
+                    }
+                } header: {
+                    Text("リンク一覧")
+                        .font(.footnote)
+                        .fontWeight(.bold)
+                        .offset(x: -15)
+                }
+            } //Form
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("記事の追加・削除")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Image(systemName: "chevron.backward")
+                        .onTapGesture {
+                            isPresented = false
+                        }
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        Task {
+                            try await viewModel.addLink(urls: articleUrls)
+                            await viewModel.fetchArticleUrls()
+                        }
+                    } label: {
+                        HStack(spacing: 2) {
+                            Image(systemName: "square.and.arrow.down")
+                            Text("追加")
+                                .fontWeight(.bold)
+                                .offset(y: 3)
+                        }
+                    }
+
+                }
+            }
+        } // navigationstack
     }
-    private func deleteAbstract(url: String) {
-       Task {
-           await abstractModel.deleteAbstractLink(url: url)
-           await abstractModel.loadAbstractLinks()
-       }
-   }
+}
+
+#Preview {
+    EditAbstractView(isPresented: .constant(true))
+        .environmentObject(ArticleLinksViewModel())
 }
 

--- a/NearU/View/Profile/View/SiteLinkButtonView.swift
+++ b/NearU/View/Profile/View/SiteLinkButtonView.swift
@@ -9,52 +9,81 @@ import SwiftUI
 import OpenGraph
 
 struct SiteLinkButtonView: View {
+    @EnvironmentObject var viewModel: ArticleLinksViewModel
+    @State private var isShowAlert: Bool = false
     let ogpData: OpenGraphData
     var showDeleteButton: Bool
+    var isOpenURL: Bool = false
 
     var body: some View {
-        Button {
-            if let url = URL(string: ogpData.url) {
-                UIApplication.shared.open(url)
-            }
-        }label: {
-            VStack(alignment: .leading) {
-                if let data = ogpData.openGraph {
-                    // メタデータが取得できた場合のリンクプレビュー
-                    VStack(alignment: .leading) {
-                        if let imageUrl = data[.image], let url = URL(string: imageUrl) {
-                            AsyncImage(url: url) { image in
-                                image
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(height: 100)
-                                    .cornerRadius(10)
-                            } placeholder: {
-                                Color.gray.frame(height: 100).cornerRadius(10)
+        ZStack(alignment: .topTrailing) {
+            Button {
+                if let url = URL(string: ogpData.url) {
+                    UIApplication.shared.open(url)
+                }
+            } label: {
+                VStack(alignment: .leading) {
+                    if let data = ogpData.openGraph {
+                        // メタデータが取得できた場合のリンクプレビュー
+                        VStack(alignment: .leading) {
+                            if let imageUrl = data[.image], let url = URL(string: imageUrl) {
+                                AsyncImage(url: url) { image in
+                                    image
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(height: 100)
+                                        .cornerRadius(10)
+                                } placeholder: {
+                                    Color.gray.frame(height: 100).cornerRadius(10)
+                                }
+                            }
+                            // タイトルがない場合はurlを表示
+                            if let title = data[.title], !title.isEmpty {
+                                Text(title)
+                                    .font(.headline)
+                                    .lineLimit(1)
+                            } else {
+                                Text(ogpData.url.count > 35 ? String(ogpData.url.prefix(35)) + "..." : ogpData.url)
+                                    .font(.headline)
+                                    .lineLimit(1)
+                                    .padding(.bottom, 2)
+                            }
+                            //.padding(.leading, 15)
+                        }// Vstack
+                        .padding()
+                        .frame(width: 350, height: 150, alignment: .leading)
+                        .background(Color.white)
+                        .cornerRadius(10)
+                        .shadow(radius: 5)
+                    } //vstack
+                } //vstack
+            } //button
+            .buttonStyle(PlainButtonStyle())
+            .disabled(!isOpenURL)
+
+            if showDeleteButton {
+                Button {
+                    isShowAlert.toggle()
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.black)
+                        .padding()
+                }
+                .alert("確認", isPresented: $isShowAlert) {
+                    Button("削除", role: .destructive) {
+                        Task {
+                            await viewModel.removeArticle(url: ogpData.url)
+                            await viewModel.fetchArticleUrls()
+                            await MainActor.run {
+                                isShowAlert.toggle()
                             }
                         }
-                        // タイトルがない場合はurlを表示
-                        if let title = data[.title], !title.isEmpty {
-                            Text(title)
-                                .font(.headline)
-                                .lineLimit(1)
-                        } else {
-                            Text(ogpData.url.count > 35 ? String(ogpData.url.prefix(35)) + "..." : ogpData.url)
-                                .font(.headline)
-                                .lineLimit(1)
-                                .padding(.bottom, 2)
-                        }
-                        //.padding(.leading, 15)
-                    }// Vstack
-                    .padding()
-                    .frame(width: 350, height: 150, alignment: .leading)
-                    .background(Color.white)
-                    .cornerRadius(10)
-                    .shadow(radius: 5)
-                } //vstack
-            } //vstack
-        } //button
-        .buttonStyle(PlainButtonStyle())
+                    }
+                } message: {
+                    Text("このリンクを削除しますか？")
+                }
+            }
+        } //zstack
     }//body
 } //view
 

--- a/NearU/View/Profile/View/SiteLinkButtonView.swift
+++ b/NearU/View/Profile/View/SiteLinkButtonView.swift
@@ -10,6 +10,7 @@ import OpenGraph
 
 struct SiteLinkButtonView: View {
     let ogpData: OpenGraphData
+    var showDeleteButton: Bool
 
     var body: some View {
         Button {

--- a/NearU/View/Profile/ViewModel/ArticleLinksViewModel.swift
+++ b/NearU/View/Profile/ViewModel/ArticleLinksViewModel.swift
@@ -88,4 +88,21 @@ class ArticleLinksViewModel: ObservableObject {
             }
         }
     }
+
+    func removeArticle(url: String) async {
+        // Firestoreから削除
+        do {
+            print(url)
+            try await UserService.deleteArticleLink(url: url)
+        } catch {
+            print("Error removing article: \(error)")
+        }
+        // UI更新
+        await MainActor.run {
+            if let index = openGraphData.firstIndex(where: { $0.url == url }) {
+                openGraphData.remove(at: index)
+            }
+        }
+
+    }
 }

--- a/NearU/View/Profile/ViewModel/ArticleLinksViewModel.swift
+++ b/NearU/View/Profile/ViewModel/ArticleLinksViewModel.swift
@@ -13,7 +13,6 @@ import Combine
 class ArticleLinksViewModel: ObservableObject {
     @Published var selectedSNS: String = ""
     @Published var snsUrl: String = ""
-    @Published var articleUrls: [String] = []
     @Published var openGraphData: [OpenGraphData] = []
     private var cancellable: AnyCancellable?
 
@@ -39,7 +38,7 @@ class ArticleLinksViewModel: ObservableObject {
         }
     }
 
-    func addLink() async throws {
+    func addLink(urls: [String]) async throws {
         guard let userId = AuthService.shared.currentUser?.id else { return }
         // SNSリンクが入力されている場合の更新
         if !selectedSNS.isEmpty && !snsUrl.isEmpty {
@@ -50,7 +49,7 @@ class ArticleLinksViewModel: ObservableObject {
         }
 
         // 複数のURLが入力されている場合の更新
-        for url in articleUrls {
+        for url in urls {
             if !url.isEmpty {
                 do {
                     try await UserService.seveArticleLink(userId: userId, url: url)

--- a/NearU/View/Profile/ViewModel/CurrentUserProfileViewModel.swift
+++ b/NearU/View/Profile/ViewModel/CurrentUserProfileViewModel.swift
@@ -146,14 +146,4 @@ class CurrentUserProfileViewModel: ObservableObject {
             print("complete")
         }
     }
-
-    @MainActor
-    func deleteAbstractLink(url: String) async {
-        do {
-            try await UserService.deleteAbstractLink(userId: user.id, url: url)
-            await loadAbstractLinks()  // 削除後にリロードしてUI更新
-        } catch {
-            print("Failed to delete abstract link: \(error)")
-        }
-    }
 }


### PR DESCRIPTION
## 概要 
記事の削除を含む編集部分を作成

## やり残し
記事の編集画面でFormを使っているため，削除ボタンがうまく作動しなかった．
一旦disabledモディファイアで応急処置．
記事の編集画面はFormを使わない設計が必要そう．

