### PR TITLE
NavigationDestinationによる遷移を廃止

### DIFF
--- a/NearU/View/MainCompornents/ProfileHeaderView.swift
+++ b/NearU/View/MainCompornents/ProfileHeaderView.swift
@@ -82,11 +82,15 @@ struct ProfileHeaderView: View {
                     }
 
                     HStack {
-                        NavigationLink(value: NavigationData(selectedTab: 0)) {
+                        NavigationLink {
+                            UserFollowFollowerView(viewModel: viewModel, selectedTab: 0)
+                        } label: {
                             CountView(count: viewModel.follows.count, text: "フォロー")
                         }
 
-                        NavigationLink(value: NavigationData(selectedTab: 1)) {
+                        NavigationLink {
+                            UserFollowFollowerView(viewModel: viewModel, selectedTab: 1)
+                        } label: {
                             CountView(count: viewModel.followers.count, text: "フォロワー")
                         }
 
@@ -156,9 +160,6 @@ struct ProfileHeaderView: View {
             }
             .padding(.bottom)
         }//vstack
-        .navigationDestination(for: NavigationData.self) { data in
-            UserFollowFollowerView(viewModel: viewModel, selectedTab: data.selectedTab)
-        }
         .alert("確認", isPresented: $isShowCheck) {
             Button("戻る", role: .cancel) {
                 isShowCheck.toggle()
@@ -180,10 +181,6 @@ struct ProfileHeaderView: View {
         }
     }//body
 }//view
-
-struct NavigationData: Hashable {
-    let selectedTab: Int
-}
 
 #Preview {
     ProfileHeaderView(viewModel: ProfileViewModel(user: User.MOCK_USERS[1], currentUser: User.MOCK_USERS[0]),

--- a/NearU/View/MainCompornents/UserRowView.swift
+++ b/NearU/View/MainCompornents/UserRowView.swift
@@ -7,8 +7,7 @@
 
 import SwiftUI
 
-struct UserRowView<T>: View where T: Hashable {
-    let value: T
+struct UserRowView: View {
     let user: User
     let date: Date?
     let isRead: Bool?
@@ -16,62 +15,60 @@ struct UserRowView<T>: View where T: Hashable {
     let isFollower: Bool?
 
     var body: some View {
-        NavigationLink(value: value) {
-            HStack {
-                CircleImageView(user: user, size: .xsmall, borderColor: .clear)
+        HStack {
+            CircleImageView(user: user, size: .xsmall, borderColor: .clear)
 
-                VStack(alignment: .leading) {
+            VStack(alignment: .leading) {
+                HStack {
+                    Text(user.username)
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.black)
+
+                    Circle()
+                        .frame(width: 8, height: 8)
+                        .foregroundColor(isRead ?? false ? .clear : .mint)
+
+                }
+
+                if isFollower == true {
+                    Text("フォローされています")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+            }
+            .padding(.leading, 5)
+
+            Spacer()
+
+            VStack {
+                if let rssi = rssi {
                     HStack {
-                        Text(user.username)
-                            .font(.subheadline)
-                            .fontWeight(.bold)
-                            .foregroundStyle(.black)
+                        Text("推定距離")
+                            .font(.caption)
+                            .foregroundColor(.gray)
 
-                        Circle()
-                            .frame(width: 8, height: 8)
-                            .foregroundColor(isRead ?? false ? .clear : .mint)
-
-                    }
-
-                    if isFollower == true {
-                        Text("フォローされています")
+                        Text(distance(fromRSSI: rssi))
                             .font(.caption)
                             .foregroundColor(.gray)
                     }
                 }
-                .padding(.leading, 5)
 
-                Spacer()
+                if let date = date {
+                    HStack {
+                        Text("最後のすれちがい")
+                            .font(.caption)
+                            .foregroundColor(.gray)
 
-                VStack {
-                    if let rssi = rssi {
-                        HStack {
-                            Text("推定距離")
-                                .font(.caption)
-                                .foregroundColor(.gray)
-
-                            Text(distance(fromRSSI: rssi))
-                                .font(.caption)
-                                .foregroundColor(.gray)
-                        }
-                    }
-
-                    if let date = date {
-                        HStack {
-                            Text("最後のすれちがい")
-                                .font(.caption)
-                                .foregroundColor(.gray)
-
-                            Text(formattedDate(from: date))
-                                .font(.caption)
-                                .foregroundColor(.gray)
-                        }
+                        Text(formattedDate(from: date))
+                            .font(.caption)
+                            .foregroundColor(.gray)
                     }
                 }
-            } //hstack
-            .foregroundStyle(.black)
-            .padding(.horizontal)
-        }
+            }
+        } //hstack
+        .foregroundStyle(.black)
+        .padding(.horizontal)
     }
 
     // フォーマッターを追加
@@ -123,8 +120,7 @@ struct UserRowView<T>: View where T: Hashable {
 }
 
 #Preview {
-    UserRowView(value: UserHistoryRecord(user: User.MOCK_USERS[0], date: Date(), isRead: true),
-                user: User.MOCK_USERS[0],
+    UserRowView(user: User.MOCK_USERS[0],
                 date: Date(),
                 isRead: false,
                 rssi: -35,

--- a/NearU/View/Profile/View/CurrentUser/View/FollowView.swift
+++ b/NearU/View/Profile/View/CurrentUser/View/FollowView.swift
@@ -23,18 +23,18 @@ struct FollowView: View {
                         .padding()
                 } else {
                     ForEach(viewModel.followUsers, id: \.self) { followUser in
-                        //TODO: isFollowerを動的に設定
-                        UserRowView(value: followUser.pair, user: followUser.pair.user,
-                                    date: followUser.pair.date, isRead: true,
-                                    rssi: nil, isFollower: followUser.isFollowed)
+                        NavigationLink {
+                            ProfileView(user: followUser.pair.user, currentUser: currentUser, date: followUser.pair.date,
+                                        isShowFollowButton: true, isShowDateButton: true)
+                        } label: {
+                            UserRowView(user: followUser.pair.user,
+                                        date: followUser.pair.date, isRead: true,
+                                        rssi: nil, isFollower: followUser.isFollowed)
+                        }
                     }//foreach
                 }
             }//lazyvstack
             .padding(.top, 8)
-            .navigationDestination(for: UserDatePair.self, destination: { pair in
-                ProfileView(user: pair.user, currentUser: currentUser, date: pair.date,
-                            isShowFollowButton: true, isShowDateButton: true)
-            })
             
         }//scrollview
         .refreshable {

--- a/NearU/View/Profile/View/CurrentUser/View/FollowerView.swift
+++ b/NearU/View/Profile/View/CurrentUser/View/FollowerView.swift
@@ -23,20 +23,21 @@ struct FollowerView: View {
                         .padding()
                 } else {
                     ForEach(viewModel.followers, id: \.self) { follower in
-                        UserRowView(value: follower, user: follower.user, date: follower.date, isRead: follower.isRead, rssi: nil, isFollower: false)
+                        NavigationLink {
+                            ProfileView(user: follower.user, currentUser: currentUser, date: follower.date,
+                                        isShowFollowButton: true, isShowDateButton: true)
+                                .onAppear {
+                                    Task {
+                                        await viewModel.updateRead(userId: follower.user.id)
+                                    }
+                                }
+                        } label: {
+                            UserRowView(user: follower.user, date: follower.date, isRead: follower.isRead, rssi: nil, isFollower: false)
+                        }
                     } //foreach
                 }
             } //lazyvstack
             .padding(.top, 8)
-            .navigationDestination(for: UserHistoryRecord.self, destination: { follower in
-                ProfileView(user: follower.user, currentUser: currentUser, date: follower.date,
-                            isShowFollowButton: true, isShowDateButton: true)
-                    .onAppear {
-                        Task {
-                            await viewModel.updateRead(userId: follower.user.id)
-                        }
-                    }
-            })
 
         } //scrollview
         .refreshable {

--- a/NearU/View/Profile/View/User/View/UserFollowView.swift
+++ b/NearU/View/Profile/View/User/View/UserFollowView.swift
@@ -22,16 +22,16 @@ struct UserFollowView: View {
                         .padding()
                 } else {
                     ForEach(viewModel.follows, id: \.self) { followUser in
-                        //TODO: できたらdate, isFollowerを動的に設定
-                        UserRowView(value: followUser.pair, user: followUser.pair.user, date: nil, isRead: true, rssi: nil, isFollower: followUser.isFollowed)
+                        NavigationLink {
+                            ProfileView(user: followUser.pair.user, currentUser: viewModel.currentUser, date: followUser.pair.date,
+                                        isShowFollowButton: false, isShowDateButton: false)
+                        } label: {
+                            UserRowView(user: followUser.pair.user, date: nil, isRead: true, rssi: nil, isFollower: followUser.isFollowed)
+                        }
                     }//foreach
                 }
             }//lazyvstack
             .padding(.top, 8)
-            .navigationDestination(for: UserDatePair.self, destination: { pair in
-                ProfileView(user: pair.user, currentUser: viewModel.currentUser, date: pair.date,
-                            isShowFollowButton: false, isShowDateButton: false)
-            })
 
         }//scrollview
         .refreshable {

--- a/NearU/View/Profile/View/User/View/UserFollowerView.swift
+++ b/NearU/View/Profile/View/User/View/UserFollowerView.swift
@@ -21,16 +21,16 @@ struct UserFollowerView: View {
                         .padding()
                 } else {
                     ForEach(viewModel.followers, id: \.self) { follower in
-                        //TODO: できたらdate, isFollowerを動的に設定
-                        UserRowView(value: follower.record, user: follower.record.user, date: nil, isRead: true, rssi: nil, isFollower: follower.isFollowed)
+                        NavigationLink {
+                            ProfileView(user: follower.record.user, currentUser: viewModel.currentUser, date: follower.record.date,
+                                        isShowFollowButton: false, isShowDateButton: false)
+                        } label: {
+                            UserRowView(user: follower.record.user, date: nil, isRead: true, rssi: nil, isFollower: follower.isFollowed)
+                        }
                     } //foreach
                 }
             } //lazyvstack
             .padding(.top, 8)
-            .navigationDestination(for: UserHistoryRecord.self, destination: { follower in
-                ProfileView(user: follower.user, currentUser: viewModel.currentUser, date: follower.date,
-                            isShowFollowButton: false, isShowDateButton: false)
-            })
 
         } //scrollview
         .refreshable {

--- a/NearU/View/Search/View/BLEHistoryView.swift
+++ b/NearU/View/Search/View/BLEHistoryView.swift
@@ -25,21 +25,22 @@ struct BLEHistoryView: View {
                         .padding()
                 } else {
                     ForEach(viewModel.sortedHistoryRowData, id: \.self) { data in
-                        // TODO: isFollowerを動的に設定
-                        UserRowView(value: data.record, user: data.record.user,
-                                    date: data.record.date, isRead: data.record.isRead,
-                                    rssi: nil, isFollower: data.isFollowed)
+                        NavigationLink {
+                            ProfileView(user: data.record.user, currentUser: currentUser, date: data.record.date,
+                                        isShowFollowButton: true, isShowDateButton: true)
+                                .onAppear {
+                                    viewModel.markAsRead(data.record)
+                                }
+                        } label: {
+                            UserRowView(user: data.record.user,
+                                        date: data.record.date, isRead: data.record.isRead,
+                                        rssi: nil, isFollower: data.isFollowed)
+                        }
                     } // ForEach
                 }
             } // LazyVStack
             .padding(.top, 8)
-            .navigationDestination(for: UserHistoryRecord.self, destination: { pair in
-                ProfileView(user: pair.user, currentUser: currentUser, date: pair.date,
-                            isShowFollowButton: true, isShowDateButton: true)
-                    .onAppear {
-                        viewModel.markAsRead(pair)
-                    }
-            })
+
         } // ScrollView
         .refreshable {
             loadingViewModel.isLoading = true

--- a/NearU/View/Search/View/BLERealtimeView.swift
+++ b/NearU/View/Search/View/BLERealtimeView.swift
@@ -26,15 +26,17 @@ struct BLERealtimeView: View {
                         .padding()
                 } else {
                     ForEach(viewModel.sortedUserRealtimeRecords, id: \.self) { pair in
-                        UserRowView(value: pair, user: pair.user, date: nil, isRead: nil, rssi: pair.rssi, isFollower: false)
+                        NavigationLink {
+                            ProfileView(user: pair.user, currentUser: currentUser, date: pair.date,
+                                        isShowFollowButton: true, isShowDateButton: true)
+                        } label: {
+                            UserRowView(user: pair.user, date: nil, isRead: nil, rssi: pair.rssi, isFollower: false)
+                        }
                     } // ForEach
                 }
             } // LazyVStack
             .padding(.top, 8)
-            .navigationDestination(for: UserRealtimeRecord.self, destination: { pair in
-                ProfileView(user: pair.user, currentUser: currentUser, date: pair.date,
-                            isShowFollowButton: true, isShowDateButton: true)
-            })
+            
         } // ScrollView
         .alert("エラー", isPresented: $isShowAlert) {
             Button("OK", role: .cancel) { }


### PR DESCRIPTION
## 概要
階層的にフォロー，フォロワーを遷移していくと正しいフォロフォロワー一覧が取得できなくなる問題の修正

## 変更点
フォロー，フォロワーを遷移していくと，同じ型のデータに対して複数の navigationDestination が定義されてしまうという問題があった．
そのため，NavigationDestinationによる遷移をやめ，単純なNavigationLinkによる遷移に変更