### PR TITLE
選んだものと別のタグが削除されるバグを修正

### DIFF
--- a/NearU/View/Profile/View/ProfileCompornents/InterestTagView.swift
+++ b/NearU/View/Profile/View/ProfileCompornents/InterestTagView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct InterestTagView: View {
-    @State private var isShowAlert: Bool = false
+    @State private var tagToDelete: InterestTag?
     @EnvironmentObject var viewModel: CurrentUserProfileViewModel
     let interestTag: [InterestTag]
     let isShowDeleteButton: Bool
@@ -34,22 +34,12 @@ struct InterestTagView: View {
                     .overlay(alignment: .topTrailing) {
                         if isShowDeleteButton {
                             Button {
-                                isShowAlert.toggle()
+                                tagToDelete = tag // 削除対象のタグを設定
                             } label: {
                                 Image(systemName: "minus.circle.fill")
                                     .font(.footnote)
                                     .foregroundStyle(.black)
                                     .offset(x: 8, y: -5)
-                            }
-                            .alert("確認", isPresented: $isShowAlert) {
-                                Button("削除", role: .destructive) {
-                                    Task {
-                                        await UserService.deleteInterestTags(id: tag.id.uuidString)
-                                        await viewModel.loadInterestTags()
-                                    }
-                                }
-                            } message: {
-                                Text("このタグを削除しますか？")
                             }
                         }
                     }
@@ -57,6 +47,19 @@ struct InterestTagView: View {
             }
         }
         .frame(height: 40)
+        .alert(item: $tagToDelete) { tag in
+            Alert(
+                title: Text("確認"),
+                message: Text("このタグを削除しますか？"),
+                primaryButton: .destructive(Text("削除")) {
+                    Task {
+                        await UserService.deleteInterestTags(id: tag.id.uuidString)
+                        await viewModel.loadInterestTags()
+                    }
+                },
+                secondaryButton: .cancel()
+            )
+        }
     }
 }
 

--- a/NearU/View/Profile/View/ProfileCompornents/InterestTagView.swift
+++ b/NearU/View/Profile/View/ProfileCompornents/InterestTagView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct InterestTagView: View {
+    @State private var isShowAlert: Bool = false
     @State private var tagToDelete: InterestTag?
     @EnvironmentObject var viewModel: CurrentUserProfileViewModel
     let interestTag: [InterestTag]
@@ -34,7 +35,8 @@ struct InterestTagView: View {
                     .overlay(alignment: .topTrailing) {
                         if isShowDeleteButton {
                             Button {
-                                tagToDelete = tag // 削除対象のタグを設定
+                                tagToDelete = tag
+                                isShowAlert = true
                             } label: {
                                 Image(systemName: "minus.circle.fill")
                                     .font(.footnote)
@@ -47,18 +49,16 @@ struct InterestTagView: View {
             }
         }
         .frame(height: 40)
-        .alert(item: $tagToDelete) { tag in
-            Alert(
-                title: Text("確認"),
-                message: Text("このタグを削除しますか？"),
-                primaryButton: .destructive(Text("削除")) {
-                    Task {
-                        await UserService.deleteInterestTags(id: tag.id.uuidString)
-                        await viewModel.loadInterestTags()
-                    }
-                },
-                secondaryButton: .cancel()
-            )
+        .alert("確認", isPresented: $isShowAlert, presenting: tagToDelete) { tag in
+            Button("削除", role: .destructive) {
+                Task {
+                    await UserService.deleteInterestTags(id: tag.id.uuidString)
+                    await viewModel.loadInterestTags()
+                    tagToDelete = nil // 削除後にリセット
+                }
+            }
+        } message: { tag in
+            Text("このタグを削除しますか？")
         }
     }
 }


### PR DESCRIPTION
## 原因
ForEachループ内で全てのアイテムが単一のisShowAlertを共有しており，どのタグを削除するのかという情報が保存されないため，ForEach内でどのボタンが押されたかを正確に追跡できなかった．
結果的に，削除ボタンを押したときにForEachループの最後が参照されるようになっていたぽい．

## 改善
選んだタグそのものを変数に格納するようにした

