### PR TITLE
データのロードが完了してからビューを表示

### DIFF
--- a/NearU/View/MainCompornents/CountView.swift
+++ b/NearU/View/MainCompornents/CountView.swift
@@ -10,16 +10,15 @@ import SwiftUI
 struct CountView: View {
     let count: Int
     let text: String
-    
+
     var body: some View {
         HStack(spacing: 3) {
             Text("\(count)")
-                .fontWeight(.bold)
+                .fontWeight(.heavy)
 
             Text(text)
-                .font(.footnote)
-                .fontWeight(.semibold)
-                .foregroundColor(.gray)
+                .font(.caption)
+                .foregroundStyle(.black)
         }
     }
 }

--- a/NearU/View/MainCompornents/ProfileHeaderView.swift
+++ b/NearU/View/MainCompornents/ProfileHeaderView.swift
@@ -146,7 +146,7 @@ struct ProfileHeaderView: View {
 
                     if let bio = viewModel.user.bio {
                         Text(bio)
-                            .font(.footnote)
+                            .font(.subheadline)
                             .frame(width: 250, alignment: .leading)
                     }
 

--- a/NearU/View/MainCompornents/ProfileHeaderView.swift
+++ b/NearU/View/MainCompornents/ProfileHeaderView.swift
@@ -118,7 +118,7 @@ struct ProfileHeaderView: View {
                                             do {
                                                 try await viewModel.followUser(date: date)
                                                 await viewModel.checkFollow()
-                                                try await viewModel.loadFollowers()
+                                                await viewModel.loadFollowers()
                                                 loadingViewModel.isLoading = false
                                             } catch {
                                                 loadingViewModel.isLoading = false
@@ -168,7 +168,7 @@ struct ProfileHeaderView: View {
                 Task {
                     try await UserService.deleteFollowedUser(receivedId: viewModel.user.id)
                     await viewModel.checkFollow()
-                    try await viewModel.loadFollowers()
+                    await viewModel.loadFollowers()
                 }
             }
         } message: {

--- a/NearU/View/MainCompornents/WordCloudView.swift
+++ b/NearU/View/MainCompornents/WordCloudView.swift
@@ -47,11 +47,11 @@ enum Style: String{
     func fontWeight() -> Font.Weight {
         switch self {
         case .one:
-            return .black
-        case .two:
-            return .heavy
-        case .three:
             return .bold
+        case .two:
+            return .bold
+        case .three:
+            return .regular
         case .four:
             return .heavy
         case .five:
@@ -66,7 +66,6 @@ struct WordCloudView: View {
     @State private var canvasRect = CGRect()
     @State private var wordSizes: [CGSize]
     @State private var wordVisibility: [Bool]
-    @State private var scale: CGFloat = 1
     @State private var offset: CGSize = .zero
     @State private var positionsReady = false
     @State private var positions: [CGPoint] = []
@@ -110,13 +109,24 @@ struct WordCloudView: View {
             }
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    Text("スキルレベル")
+                    Text("開発スキル")
                         .font(.headline)
                         .fontWeight(.bold)
                 }
             }
         } // vstack
         .offset(x: offset.width, y: offset.height)
+        .gesture(
+            DragGesture()
+                .onChanged({ value in
+                    offset = value.translation //ドラッグジェスチャーの移動量
+                })
+                .onEnded({ _ in
+                    withAnimation(.spring){
+                        offset = .zero
+                    }
+                })
+        )
     }
     @ViewBuilder
     private func selectedTagsView(tags: [WordElement], pos: [CGPoint]) -> some View {

--- a/NearU/View/Profile/View/CurrentUser/View/CurrentUserProfileView.swift
+++ b/NearU/View/Profile/View/CurrentUser/View/CurrentUserProfileView.swift
@@ -69,7 +69,7 @@ struct CurrentUserProfileView: View {
 
                                         if let bio = user.bio {
                                             Text(bio)
-                                                .font(.callout)
+                                                .font(.subheadline)
                                                 .frame(alignment: .leading)
                                         }
 
@@ -171,8 +171,8 @@ struct CurrentUserProfileView: View {
                                 }
                             } // HStack
                             .padding(.vertical, 5)
+                            .padding(.horizontal, 10)
                         } // ScrollView
-                    
                         .padding(.bottom, 10)
 
                         //MARK: - ARTICLES

--- a/NearU/View/Profile/View/CurrentUser/View/EditSkillTagsView.swift
+++ b/NearU/View/Profile/View/CurrentUser/View/EditSkillTagsView.swift
@@ -32,6 +32,16 @@ struct EditSkillTagsView: View {
                             .padding(.leading, 5)
                             .padding(.vertical, 8)
 
+                        Text("""
+                        1：基本的な文法を学んだことがある程度
+                        2：他者のサポートを受けつつ、小規模なタスクを実装できる
+                        3：参考書やインターネットで調べながら、自身で実装を進められる
+                        4：実装が複雑なアプリケーションを開発できる
+                        5：テックリードとしてエンジニアを指導し、開発を進められる
+                        """)
+                        .font(.caption)
+                        .foregroundStyle(.gray)
+
                         ForEach($languages) { language in
                             SkillTagRowView(viewModel: viewModel,
                                             language: language,
@@ -63,7 +73,7 @@ struct EditSkillTagsView: View {
                             .padding(.leading, 5)
                             .padding(.vertical, 10)
 
-                        if viewModel.Tags.isEmpty {
+                        if viewModel.skillSortedTags.isEmpty {
                             Text("保存された技術タグがありません")
                                 .font(.subheadline)
                                 .fontWeight(.bold)
@@ -71,7 +81,7 @@ struct EditSkillTagsView: View {
                                 .padding()
                         } else {
                             VStack(spacing: 20){
-                                ForEach($viewModel.Tags) { $language in
+                                ForEach($viewModel.skillSortedTags) { $language in
                                     SkillTagRowView(viewModel: viewModel,
                                                     language: $language,
                                                     skillLevels: viewModel.skillLevels,
@@ -105,7 +115,7 @@ struct EditSkillTagsView: View {
                                 }
                             } label: {
                                 HStack(spacing: 2) {
-                                    Image(systemName: "plus.app")
+                                    Image(systemName: "checkmark.circle")
                                     Text("保存")
                                         .font(.subheadline)
                                         .fontWeight(.bold)
@@ -202,14 +212,14 @@ struct TechTagPickerView: View {
         "データベース": ["MySQL", "PostgreSQL", "MongoDB", "Redis", "MariaDB", "DynamoDB"],
         "その他": ["AWS", "GCP", "Azure", "Cloudflare", "Vercel", "Firebase", "Supabase", "Terraform", "Unity", "Blender", "Docker", "ROS"],
     ]
-    
+
     // 表示順を指定
     let displayOrder: [String] = ["言語", "フレームワーク", "データベース", "その他"]
-    
+
     @Binding var language: WordElement
     @Environment(\.presentationMode) var presentationMode
     @State private var expandedSections: [String: Bool] = [:] // セクションの開閉状態を管理
-    
+
     var body: some View {
         NavigationView {
             List {
@@ -272,11 +282,11 @@ struct TechTagPickerView: View {
             }
         }
     }
-    
+
     private func toggleSection(_ category: String) {
         expandedSections[category]?.toggle()
     }
-    
+
     private let iconMapping: [String: String] = [
         // 言語
         "JavaScript": "JavaScript",

--- a/NearU/View/Profile/View/CurrentUser/ViewModel/EditSkillTagsViewModel.swift
+++ b/NearU/View/Profile/View/CurrentUser/ViewModel/EditSkillTagsViewModel.swift
@@ -12,9 +12,7 @@ import Combine
 class EditSkillTagsViewModel: ObservableObject {
     @Published var Tags: [WordElement] = []
     @Published var skillSortedTags: [WordElement] = []
-    @Published var interestSortedTags: [WordElement] = []
     let skillLevels = ["1", "2", "3", "4", "5"]
-    let interestLevels = ["", "1", "2", "3", "4", "5"]
 
     private var cancellables = Set<AnyCancellable>()
 

--- a/NearU/View/Profile/View/User/View/ProfileView.swift
+++ b/NearU/View/Profile/View/User/View/ProfileView.swift
@@ -31,7 +31,7 @@ struct ProfileView: View {
                     .progressViewStyle(CircularProgressViewStyle())
             } else {
                 ScrollView(.vertical, showsIndicators: false) {
-                    VStack {
+                    VStack(spacing: 0) {
                         //MARK: - HEADER
                         ProfileHeaderView(viewModel: viewModel, date: date,
                                           isShowFollowButton: isShowFollowButton,
@@ -76,6 +76,7 @@ struct ProfileView: View {
                                 }
                             }//hstack
                             .padding(.vertical, 5)
+                            .padding(.horizontal, 10)
                         }//scrollview
                         .padding(.bottom, 10)
 

--- a/NearU/View/Profile/View/User/View/ProfileView.swift
+++ b/NearU/View/Profile/View/User/View/ProfileView.swift
@@ -18,7 +18,6 @@ struct ProfileView: View {
 
     init(user: User, currentUser: User, date: Date, isShowFollowButton: Bool = false, isShowDateButton: Bool) {
         _viewModel = StateObject(wrappedValue: ProfileViewModel(user: user, currentUser: currentUser))
-
         self.date = date
         self.isShowFollowButton = (user.id == currentUser.id) ? false : isShowFollowButton
         self.isShowDateButton = isShowDateButton
@@ -27,94 +26,100 @@ struct ProfileView: View {
     var body: some View {
         ZStack{
             backgroundColor.ignoresSafeArea()
+            if viewModel.isLoading{
+                ProgressView("Loading...")
+                    .progressViewStyle(CircularProgressViewStyle())
+            } else {
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack {
+                        //MARK: - HEADER
+                        ProfileHeaderView(viewModel: viewModel, date: date,
+                                          isShowFollowButton: isShowFollowButton,
+                                          isShowDateButton: isShowDateButton)
 
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack {
-                    //MARK: - HEADER
-                    ProfileHeaderView(viewModel: viewModel, date: date,
-                                      isShowFollowButton: isShowFollowButton,
-                                      isShowDateButton: isShowDateButton)
-
-                    //MARK: - SNSLINKS
-                    HStack {
-                        Text("SNS")
-                            .font(.footnote)
-                            .fontWeight(.bold)
-                            .foregroundStyle(.gray)
-                            .padding(.leading, 10)
-
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.1))
-                            .frame(height: 1)
-                            .padding(.horizontal, 10)
-                    }
-
-                    if viewModel.user.isPrivate && !viewModel.isMutualFollow {
-                        Text("非公開アカウントです")
-                            .font(.subheadline)
-                            .fontWeight(.bold)
-                            .foregroundStyle(.gray)
-                    }
-
-                    ScrollView(.horizontal, showsIndicators: false) {
+                        //MARK: - SNSLINKS
                         HStack {
-                            if viewModel.user.snsLinks.isEmpty {
-                                Text("リンクがありません")
+                            Text("SNS")
+                                .font(.footnote)
+                                .fontWeight(.bold)
+                                .foregroundStyle(.gray)
+                                .padding(.leading, 10)
+
+                            Rectangle()
+                                .fill(Color.gray.opacity(0.1))
+                                .frame(height: 1)
+                                .padding(.horizontal, 10)
+                        }
+
+                        if viewModel.user.isPrivate && !viewModel.isMutualFollow {
+                            Text("非公開アカウントです")
+                                .font(.subheadline)
+                                .fontWeight(.bold)
+                                .foregroundStyle(.gray)
+                        }
+
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack {
+                                if viewModel.user.snsLinks.isEmpty {
+                                    Text("リンクがありません")
+                                        .font(.subheadline)
+                                        .fontWeight(.bold)
+                                        .foregroundColor(.gray)
+                                        .padding()
+                                } else {
+                                    ForEach (Array(viewModel.user.snsLinks.keys), id: \.self) { key in
+                                        if let url = viewModel.user.snsLinks[key] {
+                                            SNSLinkButtonView(selectedSNS: key, sns_url: url, isShowDeleteButton: false)
+                                                .disabled(viewModel.user.isPrivate && !viewModel.isMutualFollow)
+                                        }
+                                    }
+                                }
+                            }//hstack
+                            .padding(.vertical, 5)
+                        }//scrollview
+                        .padding(.bottom, 10)
+
+                        //MARK: - ARTICLES
+                        HStack {
+                            Text("記事")
+                                .font(.footnote)
+                                .fontWeight(.bold)
+                                .foregroundStyle(.gray)
+                                .padding(.leading, 10)
+
+                            Rectangle()
+                                .fill(Color.gray.opacity(0.1))
+                                .frame(height: 1)
+                                .padding(.horizontal, 10)
+                        }
+                        .padding(.bottom, 10)
+
+                        VStack(spacing: 20) {
+                            if viewModel.openGraphData.isEmpty {
+                                Text("記事がありません")
                                     .font(.subheadline)
                                     .fontWeight(.bold)
                                     .foregroundColor(.gray)
                                     .padding()
                             } else {
-                                ForEach (Array(viewModel.user.snsLinks.keys), id: \.self) { key in
-                                    if let url = viewModel.user.snsLinks[key] {
-                                        SNSLinkButtonView(selectedSNS: key, sns_url: url, isShowDeleteButton: false)
-                                            .disabled(viewModel.user.isPrivate && !viewModel.isMutualFollow)
-                                    }
+                                ForEach(viewModel.openGraphData) { openGraphData in
+                                    SiteLinkButtonView(ogpData: openGraphData, showDeleteButton: false)
                                 }
                             }
-                        }//hstack
-                        .padding(.vertical, 5)
-                    }//scrollview
-                    .padding(.bottom, 10)
-
-                    //MARK: - ARTICLES
-                    HStack {
-                        Text("記事")
-                            .font(.footnote)
-                            .fontWeight(.bold)
-                            .foregroundStyle(.gray)
-                            .padding(.leading, 10)
-
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.1))
-                            .frame(height: 1)
-                            .padding(.horizontal, 10)
-                    }
-                    .padding(.bottom, 10)
-
-                    VStack(spacing: 20) {
-                        if viewModel.openGraphData.isEmpty {
-                            Text("記事がありません")
-                                .font(.subheadline)
-                                .fontWeight(.bold)
-                                .foregroundColor(.gray)
-                                .padding()
-                        } else {
-                            ForEach(viewModel.openGraphData) { openGraphData in
-                                SiteLinkButtonView(ogpData: openGraphData, showDeleteButton: false)
-                            }
-                        }
-                    }//Vstack
-                    .padding(.bottom, 100)
-                } //vstack
-            }//scrollView
-            .refreshable {
-                await viewModel.loadUserData()
+                        }//Vstack
+                        .padding(.bottom, 100)
+                    } //vstack
+                }//scrollView
+                .refreshable {
+                    await viewModel.loadUserData()
+                }
             }
 
         } //zstack
         .ignoresSafeArea()
-
+        .onAppear {
+                viewModel.loadData()
+        }
     }//body
 }//view
 

--- a/NearU/View/Profile/View/User/ViewModel/ProfileViewModel.swift
+++ b/NearU/View/Profile/View/User/ViewModel/ProfileViewModel.swift
@@ -20,18 +20,41 @@ class ProfileViewModel: ObservableObject {
     @Published var interestTags: [InterestTag] = []
     @Published var isFollow: Bool = false
     @Published var isMutualFollow: Bool = false
+    @Published var isLoading: Bool = true
 
     init(user: User, currentUser: User) {
         self.user = user
         self.currentUser = currentUser
+    }
+
+    func loadData() {
         Task {
-            try await loadFollowUsers()
-            try await loadFollowers()
-            await loadSkillTags()
-            await checkFollow()
-            await checkMutualFollow()
-            await loadInterestTags()
-            await fetchArticleLinks()
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await self.loadFollowUsers()
+                }
+                group.addTask {
+                    await self.loadFollowers()
+                }
+                group.addTask {
+                    await self.loadSkillTags()
+                }
+                group.addTask {
+                    await self.checkFollow()
+                }
+                group.addTask {
+                    await self.checkMutualFollow()
+                }
+                group.addTask {
+                    await self.loadInterestTags()
+                }
+                group.addTask {
+                    await self.fetchArticleLinks()
+                }
+            }
+            await MainActor.run {
+                self.isLoading = false
+            }
         }
     }
 
@@ -99,7 +122,7 @@ class ProfileViewModel: ObservableObject {
     }
 
     @MainActor
-    func loadFollowUsers() async throws {
+    func loadFollowUsers() async {
         do {
             let pairData = try await UserService.fetchFollowedUsers(receivedId: user.id)
             var followUserRowData: [FollowUserRowData] = []
@@ -118,7 +141,7 @@ class ProfileViewModel: ObservableObject {
     }
 
     @MainActor
-    func loadFollowers() async throws {
+    func loadFollowers() async {
         do {
             let userHistoryRecords = try await UserService.fetchFollowers(receivedId: user.id)
             var historyRowData: [HistoryRowData] = []


### PR DESCRIPTION
## 概要
- プロフィールを読み込むときにデータが完全に読み込まれる前にビューが表示されるのを修正
- スキルレベルの説明文を追加
- WordCloudを自由に動かせるようにした
