### PR TITLE
BLE 通信によって画面が再描画しまくる問題を修正

### DIFF
--- a/NearU/Service/BLECentralManager.swift
+++ b/NearU/Service/BLECentralManager.swift
@@ -33,6 +33,7 @@ class BLECentralManager: NSObject, ObservableObject, CBCentralManagerDelegate {
     }
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        centralManager.delegate = self // デリゲートを再設定
         if central.state == .poweredOn {
             let isOnBluetooth = UserDefaults.standard.bool(forKey: "isOnBluetooth")
             if isOnBluetooth {

--- a/NearU/Service/BLEPeripheralManager.swift
+++ b/NearU/Service/BLEPeripheralManager.swift
@@ -28,6 +28,7 @@ class BLEPeripheralManager: NSObject, ObservableObject, CBPeripheralManagerDeleg
     }
 
     func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        peripheralManager.delegate = self // デリゲートを再設定
         if peripheral.state == .poweredOn {
             let isOnBluetooth = UserDefaults.standard.bool(forKey: "isOnBluetooth")
             if isOnBluetooth {

--- a/NearU/View/MainCompornents/UserRowView.swift
+++ b/NearU/View/MainCompornents/UserRowView.swift
@@ -63,10 +63,10 @@ struct UserRowView: View {
                     .font(.caption2)
                     .foregroundStyle(.gray)
                 } //hstack
-                .padding(.top, 10)
 
                 if !tags.isEmpty {
                     InterestTagView(interestTag: tags, isShowDeleteButton: false)
+                        .padding(.leading, 5)
                 }
 
             }// vstack

--- a/NearU/View/Search/View/BLEHistoryView.swift
+++ b/NearU/View/Search/View/BLEHistoryView.swift
@@ -47,6 +47,7 @@ struct BLEHistoryView: View {
             Task {
                 // データのフェッチ
                 await UserService.fetchNotifications()
+                RealmManager.shared.loadHistoryDataFromRealm()
                 // ローディング終了
                 //isLoading = false
                 loadingViewModel.isLoading = false


### PR DESCRIPTION
## 問題の概要
BLE通信で相手のIdを受け取るたびに画面を再描画していたが，BLE通信は何度も行われるため，常に画面を再描画していた．

## 改善
バッチ処理を追加し，頻繁に発生するデータ更新を一度に処理するように変更

