### PR TITLE
pickerで選択された画像に対する変更

### DIFF
--- a/NearU/View/Profile/View/CurrentUser/View/EditProfileView.swift
+++ b/NearU/View/Profile/View/CurrentUser/View/EditProfileView.swift
@@ -73,6 +73,7 @@ struct EditProfileView: View {
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         Button {
+                            viewModel.resetSelectedImage()
                             dismiss()
                         } label: {
                             Image(systemName: "chevron.backward")
@@ -88,6 +89,7 @@ struct EditProfileView: View {
                                 try await AuthService.shared.loadUserData()
 
                                 await MainActor.run {
+                                    viewModel.resetSelectedImage()
                                     dismiss()
                                 }
                             }

--- a/NearU/View/Profile/View/CurrentUser/View/EditProfileView.swift
+++ b/NearU/View/Profile/View/CurrentUser/View/EditProfileView.swift
@@ -35,6 +35,7 @@ struct EditProfileView: View {
                                 if let image = viewModel.backgroundImage {
                                     image
                                         .resizable()
+                                        .scaledToFit()
                                         .foregroundStyle(.white)
                                         .frame(width: UIScreen.main.bounds.width - 20, height: 250)
                                         .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/NearU/View/Profile/View/CurrentUser/ViewModel/CurrentUserProfileViewModel.swift
+++ b/NearU/View/Profile/View/CurrentUser/ViewModel/CurrentUserProfileViewModel.swift
@@ -110,4 +110,9 @@ class CurrentUserProfileViewModel: ObservableObject {
             print("complete")
         }
     }
+
+    @MainActor
+    func resetSelectedImage() {
+        backgroundImage = nil
+    }
 }


### PR DESCRIPTION
## 修正点
- Pickerで画像を選択してから保存せずに前の画面に戻った場合に，選択が無効になるように修正
- scaledtoFitを追加して画像全体が表示されるように修正