### PR TITLE
FireStoreからすれちがいデータをフェッチして表示

### DIFF
--- a/NearU/Service/HistoryService.swift
+++ b/NearU/Service/HistoryService.swift
@@ -27,4 +27,28 @@ struct HistoryService {
         }
             
     }
+    
+    static func fetchHistoryUser() async throws -> [HistoryDataStruct] {
+        guard let documentId = AuthService.shared.currentUser?.id else { return [] }
+        
+        let path = Firestore.firestore().collection("users").document(documentId).collection("history")
+        let snapshot = try await path.getDocuments()
+        
+        var historyData: [HistoryDataStruct] = []
+        
+        for document in snapshot.documents {
+            let data = try document.data(as: HistoryDataStruct.self)
+            historyData.append(data)
+        }
+        
+        return historyData
+    }
+    
+    static func changeIsRead(userId: String) async throws {
+        guard let documentId = AuthService.shared.currentUser?.id else { return }
+        
+        let path = Firestore.firestore().collection("users").document(documentId).collection("history").document(userId)
+        
+        try await path.updateData(["isRead" : true])
+    }
 }

--- a/NearU/View/Search/View/BLEHistoryView.swift
+++ b/NearU/View/Search/View/BLEHistoryView.swift
@@ -31,7 +31,9 @@ struct BLEHistoryView: View {
                             ProfileView(user: data.record.user, currentUser: currentUser, date: data.record.date,
                                         isShowFollowButton: true, isShowDateButton: true)
                                 .onAppear {
-                                    viewModel.markAsRead(data.record)
+                                    Task {
+                                        await viewModel.markAsRead(data.record)
+                                    }
                                 }
                         } label: {
                             UserRowView(user: data.record.user, tags: data.tags,
@@ -50,7 +52,7 @@ struct BLEHistoryView: View {
             Task {
                 // データのフェッチ
                 await UserService.fetchNotifications()
-                RealmHistoryManager.shared.loadHistoryDataFromRealm()
+                await viewModel.makeHistoryRowData()
                 // ローディング終了
                 //isLoading = false
                 loadingViewModel.isLoading = false

--- a/NearU/View/Search/View/SearchView.swift
+++ b/NearU/View/Search/View/SearchView.swift
@@ -7,9 +7,10 @@
 import SwiftUI
 
 struct SearchView: View {
-    //MARK: - property
+    @StateObject var historyManager = RealmHistoryManager()
     let currentUser: User
     @State private var searchText: String = ""
+    
 
     var body: some View {
         NavigationStack {


### PR DESCRIPTION
## 概要
FireStoreからすれちがいデータをフェッチして表示
コレクションの変更を監視して、自動で最新のデータが反映されるようにした

## 追加・変更点
Realmからフェッチするのではなく、FireStoreからフェッチしてデータを表示

## やり残したこと
- Realmに一時保存されるすれちがいデータをFireStoreに保存する関数において、保存できたものはRealmから消去する処理を追加したがテストできていない。

- コレクションの変更を監視して、自動で最新のデータが反映されるようにしたが、少しの変更でも全てのデータが変更されてしまうからどうにかしたい。
