### PR TITLE
Storageの圧迫を修正

### DIFF
--- a/NearU/View/Profile/View/CurrentUser/View/EditProfileView.swift
+++ b/NearU/View/Profile/View/CurrentUser/View/EditProfileView.swift
@@ -14,6 +14,7 @@ enum Field: Hashable {
 
 struct EditProfileView: View {
     @State private var isAddingNewLink = false
+    @State private var isLoading = false
     @State private var texts: [InterestTag] = [InterestTag(id: UUID(), text: "")]
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var viewModel: CurrentUserProfileViewModel
@@ -24,7 +25,6 @@ struct EditProfileView: View {
 
     var body: some View {
         NavigationStack {
-
             ZStack {
                 backgroundColor.ignoresSafeArea()
 
@@ -84,7 +84,15 @@ struct EditProfileView: View {
 
                     ToolbarItem(placement: .topBarTrailing) {
                         Button {
+                            isLoading = true
+                            
                             Task {
+                                defer {
+                                    Task { @MainActor in
+                                        isLoading = false
+                                    }
+                                }
+                                
                                 try await viewModel.updateUserData()
                                 await viewModel.saveInterestTags(tags: texts)
                                 try await AuthService.shared.loadUserData()
@@ -104,6 +112,10 @@ struct EditProfileView: View {
                             .foregroundStyle(Color.mint)
                         }
                     }
+                }
+                
+                if isLoading {
+                    LoadingView()
                 }
             }// zstack
             .modifier(EdgeSwipe())

--- a/NearU/View/Profile/View/CurrentUser/ViewModel/CurrentUserProfileViewModel.swift
+++ b/NearU/View/Profile/View/CurrentUser/ViewModel/CurrentUserProfileViewModel.swift
@@ -90,8 +90,7 @@ class CurrentUserProfileViewModel: ObservableObject {
         var data = [String: Any]() //keyがString型，valueがAnyの辞書を定義
 
         if let uiImage = uiBackgroundImage {
-            let imageUrl = try await ImageUploader.uploadImage(image: uiImage) //String型の画像のダウンロードURLが返される．
-            data["backgroundImageUrl"] = imageUrl //辞書に格納
+            try await ImageUploader.uploadImage(image: uiImage)
         }
 
         if !username.isEmpty && user.username != username {


### PR DESCRIPTION
## 概要
背景画像を編集するたびにStorageが圧迫されるのを修正

## 原因
file名にuuidを割り当てて一意にしようとしていた。

## 解決策
putDataAsyncメソッドでStorageに画像を保存していたが、ファイル名が同じなら上書きしてくれる。